### PR TITLE
Implement data storage

### DIFF
--- a/cmd/kademliactl/kademliactl.go
+++ b/cmd/kademliactl/kademliactl.go
@@ -20,7 +20,7 @@ func reader(wg *sync.WaitGroup, r io.Reader) {
 	if err != nil {
 		return
 	}
-	log.Info().Str("Response", string(buf[:n])).Msg("Received response")
+	log.Info().Msgf("Received response: %s", string(buf[:n]))
 }
 
 func readCmdLineArgs() []byte {

--- a/internal/command/parser/parser.go
+++ b/internal/command/parser/parser.go
@@ -8,6 +8,7 @@ import (
 	"kademlia/internal/commands/exit"
 	"kademlia/internal/commands/message"
 	"kademlia/internal/commands/ping"
+	"kademlia/internal/commands/storage"
 )
 
 func ParseCmd(s string) Command {
@@ -23,6 +24,8 @@ func ParseCmd(s string) Command {
 		command = new(message.Message)
 	case "exit":
 		command = new(exit.Exit)
+	case "storage":
+		command = new(storage.Storage)
 	default:
 		log.Error().Str("command", cmd).Msg("Received unknown command")
 		return nil

--- a/internal/commands/storage/storage.go
+++ b/internal/commands/storage/storage.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"kademlia/internal/datastore"
+
+	"github.com/rs/zerolog/log"
+)
+
+type Storage struct{}
+
+func (d Storage) Execute() (string, error) {
+	log.Debug().Msg("Executing storage command")
+
+	result := datastore.Store.EntriesAsString()
+
+	return result, nil
+}
+
+func (p *Storage) ParseOptions(options []string) error {
+	return nil
+}
+
+func (p *Storage) PrintUsage() {
+	log.Info().Msg("Usage: data")
+}

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -1,0 +1,53 @@
+package datastore
+
+import (
+	"fmt"
+	"kademlia/internal/kademliaid"
+)
+
+type DataMap = map[kademliaid.KademliaID]string
+
+type DataStore struct {
+	data DataMap
+}
+
+func New() DataStore {
+	return DataStore{make(DataMap)}
+}
+
+// Insert a value into the store.
+// Uses SHA-1 hash of value as key.
+func (d *DataStore) Insert(value string) {
+	id := kademliaid.NewKademliaID(&value)
+	d.data[id] = value
+}
+
+func (d *DataStore) Get(key kademliaid.KademliaID) string {
+	return d.data[key]
+}
+
+// Pretty printing of store
+func (d *DataStore) EntriesAsString() string {
+	/* Format as
+	map(
+		key1=val1
+		key2=val2
+		...
+	)
+	if non-empty, otherwise:
+	map()
+	*/
+	var s string
+	if len(d.data) != 0 {
+		s = "map("
+		for key, element := range d.data {
+			s = fmt.Sprintf("%s \n %s=%s", s, key, element)
+		}
+		s += "\n)"
+	} else {
+		s = "map()"
+	}
+	return s
+}
+
+var Store = New()

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -1,0 +1,55 @@
+package datastore_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"kademlia/internal/datastore"
+	"kademlia/internal/kademliaid"
+)
+
+func TestGet(t *testing.T) {
+	var d datastore.DataStore
+
+	// Should be able to  get
+	d = datastore.New()
+	value := "hello"
+	d.Insert(value)
+	assert.Equal(t, d.Get(kademliaid.NewKademliaID(&value)), "hello")
+
+	// Should not be able to get non-existent key
+	d = datastore.New()
+	value = "hello"
+	assert.Equal(t, d.Get(kademliaid.NewKademliaID(&value)), "")
+}
+
+func TestInsert(t *testing.T) {
+	var d datastore.DataStore
+
+	//should be able to insert
+	d = datastore.New()
+	value := "hello"
+	d.Insert(value)
+	assert.Equal(t, d.Get(kademliaid.NewKademliaID(&value)), "hello")
+}
+
+func TestEntriesAsString(t *testing.T) {
+	var d datastore.DataStore
+
+	//should print map() when empty
+	d = datastore.New()
+	assert.Equal(t, d.EntriesAsString(), "map()")
+
+	//should print key-value pairs when non-empty
+	d = datastore.New()
+	v1, v2 := "hello", "world"
+	d.Insert(v1)
+	d.Insert(v2)
+	whitespaces := regexp.MustCompile(`\s+`)
+	fmt.Println(whitespaces.ReplaceAllString(d.EntriesAsString(), ""))
+	assert.Contains(t, d.EntriesAsString(), fmt.Sprintf("%s=%s", kademliaid.NewKademliaID(&v1), v1))
+	assert.Contains(t, d.EntriesAsString(), fmt.Sprintf("%s=%s", kademliaid.NewKademliaID(&v2), v2))
+}

--- a/internal/kademliaid/kademliaid.go
+++ b/internal/kademliaid/kademliaid.go
@@ -1,7 +1,9 @@
 package kademliaid
 
 import (
+	"crypto/sha1"
 	"encoding/hex"
+	"fmt"
 	"math/rand"
 )
 
@@ -12,15 +14,12 @@ const IDLength = 20
 type KademliaID [IDLength]byte
 
 // NewKademliaID returns a new instance of a KademliaID based on the string input
-func NewKademliaID(data string) *KademliaID {
-	decoded, _ := hex.DecodeString(data)
-
-	newKademliaID := KademliaID{}
-	for i := 0; i < IDLength; i++ {
-		newKademliaID[i] = decoded[i]
-	}
-
-	return &newKademliaID
+func NewKademliaID(data *string) KademliaID {
+	// Copy into slice in order to avoid array size type checking.
+	// I'm sure there's a better way to do this...
+	id := KademliaID{}
+	copy(id[:], fmt.Sprintf("%x", sha1.Sum([]byte(*data))))
+	return id
 }
 
 // NewRandomKademliaID returns a new instance of a random KademliaID,


### PR DESCRIPTION
Closes #27, closes #28 

Adds a datastore, which is implemented as a map where the keys in the
key-value pairs are hashed created from the values.
Adds a command called store, which queries the node to print all stored
entries.