### PR TITLE
Seperate Kademlia node from main

### DIFF
--- a/cmd/kademlia/kademlia.go
+++ b/cmd/kademlia/kademlia.go
@@ -1,33 +1,22 @@
 package main
 
 import (
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"kademlia/internal/command/listener"
-	. "kademlia/internal/contact"
 	"kademlia/internal/message"
+	. "kademlia/internal/node"
 	"os"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
-
-type Kademlia struct {
-}
-
-func (kademlia *Kademlia) LookupContact(target *Contact) {
-	// TODO
-}
-
-func (kademlia *Kademlia) LookupData(hash string) {
-	// TODO
-}
-
-func (kademlia *Kademlia) Store(data []byte) {
-	// TODO
-}
 
 func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
 	log.Info().Msg("Starting node...")
+
+	KadNode.Init()
+	log.Info().Str("NodeID", KadNode.Id.String()).Msg("ID assigned")
 
 	go cmdlistener.Listen()
 	msglistener.Listen()

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,0 +1,28 @@
+package node
+
+import (
+	. "kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+)
+
+type Node struct {
+	Id *kademliaid.KademliaID
+}
+
+var KadNode Node
+
+func (node *Node) Init() {
+	KadNode = Node{Id: kademliaid.NewRandomKademliaID()}
+}
+
+func (node *Node) LookupContact(target *Contact) {
+	// TODO
+}
+
+func (node *Node) LookupData(hash string) {
+	// TODO
+}
+
+func (node *Node) Store(data []byte) {
+	// TODO
+}


### PR DESCRIPTION
Moved the kademlia node struct and methods from the main file and created
a global variable containing the node. This Node variable is initiliazed
when the node is created in the main function (currently only holds the
node id).