### PR TITLE
Implement shell script that initilizes the cluster

### DIFF
--- a/cmd/kademlia/kademlia.go
+++ b/cmd/kademlia/kademlia.go
@@ -3,7 +3,6 @@ package main
 import (
 	"kademlia/internal/command/listener"
 	"kademlia/internal/message/listener"
-	. "kademlia/internal/node"
 	"os"
 	"time"
 
@@ -14,9 +13,6 @@ import (
 func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
 	log.Info().Msg("Starting node...")
-
-	KadNode.Init()
-	log.Info().Str("NodeID", KadNode.Id.String()).Msg("ID assigned")
 
 	go cmdlistener.Listen()
 	msglistener.Listen()

--- a/internal/command/parser/parser.go
+++ b/internal/command/parser/parser.go
@@ -4,8 +4,11 @@ import (
 	"strings"
 
 	. "kademlia/internal/command"
+	"kademlia/internal/commands/addcontact"
 	"kademlia/internal/commands/exit"
 	"kademlia/internal/commands/get"
+	"kademlia/internal/commands/getid"
+	"kademlia/internal/commands/initnode"
 	"kademlia/internal/commands/message"
 	"kademlia/internal/commands/ping"
 	"kademlia/internal/commands/storage"
@@ -30,6 +33,12 @@ func ParseCmd(s string) Command {
 		command = new(storage.Storage)
 	case "get":
 		command = new(get.Get)
+	case "getid":
+		command = new(getid.GetId)
+	case "addcontact":
+		command = new(addcontact.AddContact)
+	case "init":
+		command = new(initnode.InitNode)
 	default:
 		log.Error().Str("command", cmd).Msg("Received unknown command")
 		return nil

--- a/internal/command/parser/parser_test.go
+++ b/internal/command/parser/parser_test.go
@@ -28,6 +28,23 @@ func TestParseCmd(t *testing.T) {
 	//should be able to parse a message command
 	// TODO: Should also test that target and content is set
 	cmd = cmdparser.ParseCmd("get somehash")
+
+	// should be able to parse a exit command
+	cmd = cmdparser.ParseCmd("exit")
+	assert.NotNil(t, cmd)
+
+	// should be able to parse a getid command
+	cmd = cmdparser.ParseCmd("getid")
+	assert.NotNil(t, cmd)
+
+	// should be able to parse a addcontact command
+	// TODO: Should also test that nodeID and address is set
+	cmd = cmdparser.ParseCmd("addcontact nodeid address")
+	assert.NotNil(t, cmd)
+
+	// should be able to parse a init command
+	// TODO: Should also test that address is set
+	cmd = cmdparser.ParseCmd("init address")
 	assert.NotNil(t, cmd)
 
 	//should return nil if an invalid command was passed

--- a/internal/commands/addcontact/addcontact.go
+++ b/internal/commands/addcontact/addcontact.go
@@ -1,0 +1,35 @@
+package addcontact
+
+import (
+	"errors"
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+
+	"github.com/rs/zerolog/log"
+)
+
+type AddContact struct {
+	Id      string
+	Address string
+}
+
+func (a *AddContact) Execute() (string, error) {
+	log.Debug().Msg("Executing addcontact command")
+	node.KadNode.RoutingTable.AddContact(contact.NewContact(kademliaid.FromString(a.Id), a.Address))
+	return "Contact added", nil
+}
+
+func (a *AddContact) ParseOptions(options []string) error {
+	if len(options) < 2 {
+		return errors.New("Missing contact id or address")
+	}
+
+	a.Id = options[0]
+	a.Address = options[1]
+	return nil
+}
+
+func (a *AddContact) PrintUsage() {
+	log.Info().Msg("Usage: addcontact {nodeID} {address}")
+}

--- a/internal/commands/addcontact/addcontact_test.go
+++ b/internal/commands/addcontact/addcontact_test.go
@@ -1,0 +1,48 @@
+package addcontact_test
+
+import (
+	"kademlia/internal/commands/addcontact"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOptions(t *testing.T) {
+	var addcCmd *addcontact.AddContact
+	var err error
+
+	// should not return an error if a  nodeid and address is specified
+	addcCmd = new(addcontact.AddContact)
+	err = addcCmd.ParseOptions([]string{"nodeid", "address"})
+	assert.Nil(t, err)
+
+	// should set node ID and Address
+	addcCmd = new(addcontact.AddContact)
+	err = addcCmd.ParseOptions([]string{"nodeid", "address"})
+	assert.Equal(t, addcCmd.Id, "nodeid")
+	assert.Equal(t, addcCmd.Address, "address")
+
+	// should return an error if an address is specified but not node ID
+	addcCmd = new(addcontact.AddContact)
+	err = addcCmd.ParseOptions([]string{"address"})
+	assert.NotNil(t, err)
+
+	// should return an error if a node ID is specified but not address
+	addcCmd = new(addcontact.AddContact)
+	err = addcCmd.ParseOptions([]string{"nodeid"})
+	assert.NotNil(t, err)
+}
+
+func TestExecute(t *testing.T) {
+	var addcCmd *addcontact.AddContact
+
+	// should add the contact
+	node.KadNode.Init("address")
+	addcCmd = new(addcontact.AddContact)
+	addcCmd.ParseOptions([]string{"address", kademliaid.NewRandomKademliaID().String()})
+	res, err := addcCmd.Execute()
+	assert.Equal(t, "Contact added", res)
+	assert.Nil(t, err)
+}

--- a/internal/commands/getid/getid.go
+++ b/internal/commands/getid/getid.go
@@ -1,0 +1,24 @@
+package getid
+
+import (
+	"kademlia/internal/node"
+
+	"github.com/rs/zerolog/log"
+)
+
+type GetId struct {
+}
+
+// getid returns the nodes kademlia ID
+func (g GetId) Execute() (string, error) {
+	log.Debug().Msg("Executing getid command")
+	return node.KadNode.Id.String(), nil
+}
+
+func (g *GetId) ParseOptions(options []string) error {
+	return nil
+}
+
+func (g *GetId) PrintUsage() {
+	log.Info().Msg("Usage: getid")
+}

--- a/internal/commands/getid/getid_test.go
+++ b/internal/commands/getid/getid_test.go
@@ -1,0 +1,32 @@
+package getid_test
+
+import (
+	"kademlia/internal/commands/getid"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOptions(t *testing.T) {
+	var getidCmd *getid.GetId
+	var err error
+
+	// should not return an error (since no arugments are needed)
+	getidCmd = new(getid.GetId)
+	err = getidCmd.ParseOptions([]string{""})
+	assert.Nil(t, err)
+}
+
+func TestExecute(t *testing.T) {
+	var getidCmd *getid.GetId
+
+	// should return the nodes ID
+	id := kademliaid.NewRandomKademliaID()
+	node.KadNode.Id = id
+	getidCmd = new(getid.GetId)
+	res, err := getidCmd.Execute()
+	assert.Nil(t, err)
+	assert.Equal(t, id.String(), res)
+}

--- a/internal/commands/initnode/initnode.go
+++ b/internal/commands/initnode/initnode.go
@@ -1,0 +1,46 @@
+package initnode
+
+import (
+	"errors"
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"kademlia/internal/routingtable"
+
+	"github.com/rs/zerolog/log"
+)
+
+type InitNode struct {
+	Address string
+}
+
+// Initialize the node by generating a NodeID and creating a new routing table
+// containing itself as a contact
+func (i *InitNode) Execute() (string, error) {
+	log.Debug().Msg("Executing init command")
+	log.Info().Msg("Initializing node...")
+
+	id := kademliaid.NewRandomKademliaID()
+	me := contact.NewContact(id, i.Address)
+	node.KadNode = node.Node{
+		Id:           id,
+		RoutingTable: routingtable.NewRoutingTable(me),
+	}
+
+	log.Info().Str("NodeID", id.String()).Msg("ID assigned")
+
+	return "Node initialized", nil
+}
+
+func (i *InitNode) ParseOptions(options []string) error {
+	if len(options) < 1 {
+		return errors.New("Missing address")
+	}
+
+	i.Address = options[0]
+	return nil
+}
+
+func (i *InitNode) PrintUsage() {
+	log.Info().Msg("Usage: init {address}")
+}

--- a/internal/commands/initnode/initnode_test.go
+++ b/internal/commands/initnode/initnode_test.go
@@ -1,0 +1,39 @@
+package initnode_test
+
+import (
+	"kademlia/internal/commands/initnode"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOptions(t *testing.T) {
+	var initCmd *initnode.InitNode
+	var err error
+
+	// should not return an error if an address is specified
+	initCmd = new(initnode.InitNode)
+	err = initCmd.ParseOptions([]string{"address"})
+	assert.Nil(t, err)
+
+	// should set the specified ip as the address
+	initCmd = new(initnode.InitNode)
+	err = initCmd.ParseOptions([]string{"address"})
+	assert.Equal(t, initCmd.Address, "address")
+
+	// should return an error if an address isn't specified
+	initCmd = new(initnode.InitNode)
+	err = initCmd.ParseOptions([]string{})
+	assert.NotNil(t, err)
+}
+
+func TestExecute(t *testing.T) {
+	var initCmd *initnode.InitNode
+
+	// should initialize the node
+	initCmd = new(initnode.InitNode)
+	initCmd.ParseOptions([]string{"address"})
+	res, err := initCmd.Execute()
+	assert.Equal(t, "Node initialized", res)
+	assert.Nil(t, err)
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,21 +1,29 @@
 package node
 
 import (
-	. "kademlia/internal/contact"
+	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/routingtable"
 )
 
 type Node struct {
-	Id *kademliaid.KademliaID
+	Id           *kademliaid.KademliaID
+	RoutingTable *routingtable.RoutingTable
 }
 
 var KadNode Node
 
-func (node *Node) Init() {
-	KadNode = Node{Id: kademliaid.NewRandomKademliaID()}
+// Initialize the node by generating a NodeID and creating a new routing table
+// containing itself as a contact
+func (node *Node) Init(address string) {
+	id := kademliaid.NewRandomKademliaID()
+	KadNode = Node{
+		Id:           id,
+		RoutingTable: routingtable.NewRoutingTable(contact.NewContact(id, address)),
+	}
 }
 
-func (node *Node) LookupContact(target *Contact) {
+func (node *Node) LookupContact(target *contact.Contact) {
 	// TODO
 }
 

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -1,0 +1,16 @@
+package node_test
+
+import (
+	"kademlia/internal/node"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	node.KadNode.Init("address")
+
+	// should initialize the node variables
+	assert.NotNil(t, node.KadNode.Id)
+	assert.NotNil(t, node.KadNode.RoutingTable)
+}

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -1,0 +1,25 @@
+CONT_NAME="^kademlia_kademlia." # Common part of container names
+
+echo "Initilizing all running Kademlia containers..."
+
+# Get all container IDs
+cont_ids=$(docker ps -aq -f name=$CONT_NAME -f status=running) 
+
+# Init each node with their assigned IPs
+for id in $cont_ids; do
+  cont_ip="$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id)"
+
+  docker exec -it $id kademliactl init $cont_ip > /dev/null
+done
+
+# Insert a known node in the network to each routing table
+known_node_cid="$(echo "$cont_ids" | head -n 1)"
+known_node_ip="$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $known_node_cid)"
+known_node_kadid="$(docker exec -it $id kademliactl getid | sed -ne 's/^.*response: //p')" 
+for id in $cont_ids; do
+  if [ "$id" != "$known_node_cid" ]; then
+    docker exec -it $id kademliactl addcontact "$known_node_kadid" "$known_node_ip" > /dev/null
+  fi
+done
+
+echo "Done"


### PR DESCRIPTION
init-cluster.sh initilizes all the containers in the swarm by
initilizing each containers kademlia node. This is done by inspecting
each container and getting their IPs and then executing the node init
method to setup the node.

Finally, every node except one gets a known kademlia node added to their
routing table as a contact. This allows for the nodes to join the
network once we have implemented the FIND_NODE RPC later.

To implement this three new commands were added:
- getid: The getid command returns the node ID of the node running inside the container

- addcontact: Added a new command which adds a new contact to the nodes routing table given the nodeID and address of the other node.

- init: init takes the nodes local address as an argument since this is
required for the node to create a new routing table with itself as a
contact.

Closes #43 