### PR TITLE
Add Address to seperate host and port

### DIFF
--- a/internal/address/address.go
+++ b/internal/address/address.go
@@ -1,0 +1,30 @@
+package address
+
+import ()
+import (
+	// "github.com/rs/zerolog/log"
+	"net"
+)
+
+type Address struct {
+	host string
+	port string
+}
+
+func New(address string) Address {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address // TODO: This is dumb, need to check if error is of "missing address port"
+		// log.Error().Str("Address", host).Msgf("Failed to parse given address, error: %s", err)
+
+	}
+
+	return Address{
+		host: host,
+		port: "1776", // TODO: Don't hardcore, maybe use env var?
+	}
+}
+
+func (address *Address) String() string {
+	return net.JoinHostPort(address.host, address.port)
+}

--- a/internal/address/address.go
+++ b/internal/address/address.go
@@ -4,6 +4,7 @@ import ()
 import (
 	// "github.com/rs/zerolog/log"
 	"net"
+	"strconv"
 )
 
 type Address struct {
@@ -27,4 +28,12 @@ func New(address string) Address {
 
 func (address *Address) String() string {
 	return net.JoinHostPort(address.host, address.port)
+}
+
+func (address *Address) GetHost() string {
+	return address.host
+}
+
+func (address *Address) GetPortAsInt() (int, error) {
+	return strconv.Atoi(address.port)
 }

--- a/internal/address/address_test.go
+++ b/internal/address/address_test.go
@@ -1,0 +1,23 @@
+package address_test
+
+import (
+	"kademlia/internal/address"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+
+	// should not be nil
+	assert.NotNil(t, address.New("123"))
+
+}
+
+func TestString(t *testing.T) {
+	// should be equal
+	adr := address.New("127.0.0.1:1776")
+	assert.Equal(t, adr.String(), "127.0.0.1:1776")
+
+}

--- a/internal/address/address_test.go
+++ b/internal/address/address_test.go
@@ -21,3 +21,18 @@ func TestString(t *testing.T) {
 	assert.Equal(t, adr.String(), "127.0.0.1:1776")
 
 }
+
+func TestGetHost(t *testing.T) {
+
+	// should be the same host address
+	adr := address.New("127.0.0.1:1776")
+	assert.Equal(t, adr.GetHost(), "127.0.0.1")
+}
+
+func TestGetPortAsInt(t *testing.T) {
+
+	adr := address.New("127.0.0.1:1776")
+	port, err := adr.GetPortAsInt()
+	assert.Nil(t, err)
+	assert.Equal(t, port, 1776)
+}

--- a/internal/commands/addcontact/addcontact.go
+++ b/internal/commands/addcontact/addcontact.go
@@ -2,6 +2,8 @@ package addcontact
 
 import (
 	"errors"
+	"fmt"
+	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/node"
@@ -16,8 +18,9 @@ type AddContact struct {
 
 func (a *AddContact) Execute() (string, error) {
 	log.Debug().Msg("Executing addcontact command")
-	node.KadNode.RoutingTable.AddContact(contact.NewContact(kademliaid.FromString(a.Id), a.Address))
-	return "Contact added", nil
+	adr := address.New(a.Address)
+	node.KadNode.RoutingTable.AddContact(contact.NewContact(kademliaid.FromString(a.Id), &adr))
+	return "Contact added: " + fmt.Sprint(adr.String()), nil
 }
 
 func (a *AddContact) ParseOptions(options []string) error {

--- a/internal/commands/addcontact/addcontact_test.go
+++ b/internal/commands/addcontact/addcontact_test.go
@@ -1,6 +1,7 @@
 package addcontact_test
 
 import (
+	// "fmt"
 	"kademlia/internal/commands/addcontact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/node"
@@ -39,10 +40,11 @@ func TestExecute(t *testing.T) {
 	var addcCmd *addcontact.AddContact
 
 	// should add the contact
-	node.KadNode.Init("address")
+	node.KadNode.Init("127.0.0.1:1776")
 	addcCmd = new(addcontact.AddContact)
-	addcCmd.ParseOptions([]string{"address", kademliaid.NewRandomKademliaID().String()})
+	id := kademliaid.NewRandomKademliaID().String()
+	addcCmd.ParseOptions([]string{id, "127.0.0.1:1776"})
 	res, err := addcCmd.Execute()
-	assert.Equal(t, "Contact added", res)
+	assert.Equal(t, "Contact added: 127.0.0.1:1776", res)
 	assert.Nil(t, err)
 }

--- a/internal/commands/initnode/initnode.go
+++ b/internal/commands/initnode/initnode.go
@@ -2,6 +2,7 @@ package initnode
 
 import (
 	"errors"
+	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/node"
@@ -21,7 +22,8 @@ func (i *InitNode) Execute() (string, error) {
 	log.Info().Msg("Initializing node...")
 
 	id := kademliaid.NewRandomKademliaID()
-	me := contact.NewContact(id, i.Address)
+	adr := address.New(i.Address)
+	me := contact.NewContact(id, &adr)
 	node.KadNode = node.Node{
 		Id:           id,
 		RoutingTable: routingtable.NewRoutingTable(me),

--- a/internal/commands/message/message.go
+++ b/internal/commands/message/message.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"errors"
+	"kademlia/internal/address"
 	kademliaMessage "kademlia/internal/rpc"
 	"kademlia/internal/udpsender"
 
@@ -15,9 +16,9 @@ type Message struct {
 
 func (msg Message) Execute() (string, error) {
 	log.Debug().Str("Target", msg.Target).Msg("Executing message command")
-
-	message := kademliaMessage.New(msg.Content, msg.Target)
-	udpSender := udpsender.New(msg.Target)
+	adr := address.New(msg.Target)
+	message := kademliaMessage.New(msg.Content, &adr)
+	udpSender := udpsender.New(&adr)
 	err := message.Send(udpSender)
 
 	if err != nil {

--- a/internal/commands/ping/ping.go
+++ b/internal/commands/ping/ping.go
@@ -2,6 +2,7 @@ package ping
 
 import (
 	"errors"
+	"kademlia/internal/address"
 	"kademlia/internal/network"
 
 	"github.com/rs/zerolog/log"
@@ -13,7 +14,8 @@ type Ping struct {
 
 func (p Ping) Execute() (string, error) {
 	log.Debug().Str("Target", p.Target).Msg("Executing ping command")
-	network.Net.SendPingMessage(p.Target)
+	adr := address.New(p.Target)
+	network.Net.SendPingMessage(&adr)
 
 	return "Ping sent!", nil
 

--- a/internal/commands/put/put.go
+++ b/internal/commands/put/put.go
@@ -2,7 +2,6 @@ package put
 
 import (
 	"errors"
-	"fmt"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/network"
 	"kademlia/internal/node"
@@ -25,7 +24,7 @@ func (put *Put) Execute() (string, error) {
 
 	// Send STORE RPCs
 	for _, node := range closestNodes {
-		network.Net.SendStoreMessage(fmt.Sprintf("%s:%s", node.Address, "1776"), []byte(put.fileContent))
+		network.Net.SendStoreMessage(node.Address, []byte(put.fileContent))
 	}
 
 	return "", nil

--- a/internal/contact/contact.go
+++ b/internal/contact/contact.go
@@ -2,7 +2,8 @@ package contact
 
 import (
 	"fmt"
-	. "kademlia/internal/kademliaid"
+	"kademlia/internal/address"
+	"kademlia/internal/kademliaid"
 	"sort"
 )
 
@@ -13,19 +14,19 @@ func Myprint() {
 // Contact definition
 // stores the KademliaID, the ip address and the distance
 type Contact struct {
-	ID       *KademliaID
-	Address  string
-	distance *KademliaID
+	ID       *kademliaid.KademliaID
+	Address  *address.Address
+	distance *kademliaid.KademliaID
 }
 
 // NewContact returns a new instance of a Contact
-func NewContact(id *KademliaID, address string) Contact {
+func NewContact(id *kademliaid.KademliaID, address *address.Address) Contact {
 	return Contact{id, address, nil}
 }
 
 // CalcDistance calculates the distance to the target and
 // fills the contacts distance field
-func (contact *Contact) CalcDistance(target *KademliaID) {
+func (contact *Contact) CalcDistance(target *kademliaid.KademliaID) {
 	contact.distance = contact.ID.CalcDistance(target)
 }
 
@@ -36,7 +37,7 @@ func (contact *Contact) Less(otherContact *Contact) bool {
 
 // String returns a simple string representation of a Contact
 func (contact *Contact) String() string {
-	return fmt.Sprintf(`contact("%s", "%s")`, contact.ID, contact.Address)
+	return fmt.Sprintf(`contact("%s", "%s")`, contact.ID, contact.Address.String())
 }
 
 // ContactCandidates definition

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -18,9 +18,9 @@ type Network struct{}
 func (network *Network) SendPongMessage(target *address.Address, id *kademliaid.KademliaID) {
 
 	log.Debug().Str("Address", target.String()).Msg("Sending PONG to address")
-	rpc := rpc.New("PONG", target.String())
+	rpc := rpc.New("PONG", target)
 	rpc.RPCId = id
-	udpSender := udpsender.New(target.String())
+	udpSender := udpsender.New(target)
 
 	err := rpc.Send(udpSender)
 	if err != nil {
@@ -31,8 +31,8 @@ func (network *Network) SendPongMessage(target *address.Address, id *kademliaid.
 
 // SendPingMessage sends a "PING" message to a remote address
 func (network *Network) SendPingMessage(target *address.Address) {
-	rpc := rpc.New("PING", target.String())
-	udpSender := udpsender.New(target.String())
+	rpc := rpc.New("PING", target)
+	udpSender := udpsender.New(target)
 
 	err := rpc.Send(udpSender)
 	if err != nil {
@@ -51,8 +51,8 @@ func (network *Network) SendFindDataMessage(hash string) {
 
 func (network *Network) SendStoreMessage(target *address.Address, data []byte) {
 	log.Debug().Str("Target", target.String()).Msg("Sending store message")
-	rpc := rpc.New(fmt.Sprintf("%s %s", "STORE", data), target.String())
-	udpSender := udpsender.New(target.String())
+	rpc := rpc.New(fmt.Sprintf("%s %s", "STORE", data), target)
+	udpSender := udpsender.New(target)
 	err := rpc.Send(udpSender)
 
 	if err != nil {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
@@ -18,11 +19,12 @@ var KadNode Node
 
 // Initialize the node by generating a NodeID and creating a new routing table
 // containing itself as a contact
-func (node *Node) Init(address string) {
+func (node *Node) Init(target string) {
 	id := kademliaid.NewRandomKademliaID()
+	adr := address.New(target)
 	KadNode = Node{
 		Id:           id,
-		RoutingTable: routingtable.NewRoutingTable(contact.NewContact(id, address)),
+		RoutingTable: routingtable.NewRoutingTable(contact.NewContact(id, &adr)),
 	}
 }
 

--- a/internal/rpc/parser/parser.go
+++ b/internal/rpc/parser/parser.go
@@ -27,7 +27,7 @@ func ParseRPC(sender *contact.Contact, rpc *rpc.RPC) (rpccommand.RPCCommand, err
 	switch identifier := fields[0]; identifier {
 	case "PING":
 		rpcLog.Msg("PING received")
-		cmd = ping.New(&sender.Address, rpc.RPCId)
+		cmd = ping.New(sender.Address, rpc.RPCId)
 	case "PONG":
 		rpcLog.Msg("PONG received")
 		cmd = pong.New()

--- a/internal/rpc/parser/parser_test.go
+++ b/internal/rpc/parser/parser_test.go
@@ -1,6 +1,7 @@
 package rpcparser_test
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/rpc"
@@ -15,7 +16,8 @@ import (
 )
 
 func TestParseRPC(t *testing.T) {
-	c := contact.NewContact(kademliaid.NewRandomKademliaID(), "127.0.0.1")
+	adr := address.New("127.0.0.1:1776")
+	c := contact.NewContact(kademliaid.NewRandomKademliaID(), &adr)
 	var r rpc.RPC
 	var rpcCmd rpccommand.RPCCommand
 	var err error

--- a/internal/rpc/parser/parser_test.go
+++ b/internal/rpc/parser/parser_test.go
@@ -23,31 +23,31 @@ func TestParseRPC(t *testing.T) {
 	var err error
 
 	//Should be able to parse a PING rpc
-	r = rpc.New("PING", "sometarget")
+	r = rpc.New("PING", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, ping.Ping{}, rpcCmd)
 
 	//Should be able to parse a PONG rpc
-	r = rpc.New("PONG", "sometarget")
+	r = rpc.New("PONG", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, pong.Pong{}, rpcCmd)
 
 	//Should be able to parse a STORE rpc
-	r = rpc.New("STORE", "sometarget")
+	r = rpc.New("STORE", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, &store.Store{}, rpcCmd)
 
 	//Should not parse an unknown RPC
-	r = rpc.New("HELLO", "sometarget")
+	r = rpc.New("HELLO", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.EqualError(t, err, "Received unknown RPC HELLO")
 	assert.Nil(t, rpcCmd)
 
 	//Should not parse empty string
-	r = rpc.New("", "sometarget")
+	r = rpc.New("", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "Missing RPC name")

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"errors"
 	"fmt"
+	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/node"
 	"strings"
@@ -14,14 +15,14 @@ type RPC struct {
 	SenderId *kademliaid.KademliaID
 	RPCId    *kademliaid.KademliaID
 	Content  string
-	Target   string
+	Target   *address.Address
 }
 
 type Sender interface {
 	Send(string) error
 }
 
-func New(content string, target string) RPC {
+func New(content string, target *address.Address) RPC {
 	return RPC{SenderId: node.KadNode.Id, RPCId: kademliaid.NewRandomKademliaID(), Content: content, Target: target}
 }
 

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -3,6 +3,7 @@ package rpc_test
 import (
 	"errors"
 	"fmt"
+	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/rpc"
 	"strings"
@@ -23,9 +24,10 @@ func (m *SenderMock) Send(data string) error {
 
 func TestNew(t *testing.T) {
 	var content, target = "some message", "127.0.0.1:1337"
-	rpc := rpc.New(content, target)
+	adr := address.New(target)
+	rpc := rpc.New(content, &adr)
 
-	assert.Equal(t, rpc.Target, target)
+	assert.Equal(t, rpc.Target, &adr)
 	assert.Equal(t, rpc.Content, content)
 }
 
@@ -52,7 +54,8 @@ func TestDeserialize(t *testing.T) {
 func TestSend(t *testing.T) {
 	testId := strings.Repeat("1", 40) //IDs are 160-bit (= 40 hex characters)
 	var senderMock *SenderMock
-	rpc := rpc.RPC{SenderId: kademliaid.FromString(testId), RPCId: kademliaid.FromString(testId), Content: "content", Target: "target"}
+	adr := address.New("127.0.0.1")
+	rpc := rpc.RPC{SenderId: kademliaid.FromString(testId), RPCId: kademliaid.FromString(testId), Content: "content", Target: &adr}
 	rpcSerialized := fmt.Sprintf("%s;%s;content", testId, testId)
 	var err error
 

--- a/internal/rpccommands/ping/ping.go
+++ b/internal/rpccommands/ping/ping.go
@@ -1,22 +1,23 @@
 package ping
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/network"
 )
 
 type Ping struct {
-	senderAddress *string
+	senderAddress *address.Address
 	rpcId         *kademliaid.KademliaID
 }
 
-func New(senderAddress *string, rpcId *kademliaid.KademliaID) Ping {
+func New(senderAddress *address.Address, rpcId *kademliaid.KademliaID) Ping {
 	return Ping{senderAddress: senderAddress, rpcId: rpcId}
 }
 
 func (ping Ping) Execute() {
 	// Respond with pong
-	network.Net.SendPongMessage(*ping.senderAddress, ping.rpcId)
+	network.Net.SendPongMessage(ping.senderAddress, ping.rpcId)
 }
 
 func (ping Ping) ParseOptions(options *[]string) error {

--- a/internal/rpccommands/ping/ping_test.go
+++ b/internal/rpccommands/ping/ping_test.go
@@ -1,6 +1,7 @@
 package ping_test
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/rpccommands/ping"
 	"testing"
@@ -9,8 +10,8 @@ import (
 )
 
 func TestParseOptions(t *testing.T) {
-	address := "someaddress"
-	p := ping.New(&address, kademliaid.NewRandomKademliaID())
+	adr := address.New("127.0.0.1:1776")
+	p := ping.New(&adr, kademliaid.NewRandomKademliaID())
 	options := []string{"hello", "abc"}
 	//Should never return an error
 	assert.NoError(t, p.ParseOptions(&options))

--- a/internal/udplistener/udplistener.go
+++ b/internal/udplistener/udplistener.go
@@ -1,6 +1,7 @@
 package udplistener
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/node"
 	"kademlia/internal/rpc"
@@ -32,6 +33,7 @@ func waitForMessages(c *net.UDPConn) {
 			continue
 		}
 		data := buf[0:nr]
+		adr := address.New(addr.String())
 		rpcMsg, err := rpc.Deserialize(string(data))
 		if err == nil {
 			log.Info().
@@ -40,7 +42,7 @@ func waitForMessages(c *net.UDPConn) {
 				Str("RPCId", rpcMsg.RPCId.String()).
 				Msg("Received message")
 
-			c := contact.NewContact(rpcMsg.SenderId, addr.String())
+			c := contact.NewContact(rpcMsg.SenderId, &adr)
 			node.KadNode.RoutingTable.AddContact(c)
 
 			cmd, err := rpcparser.ParseRPC(&c, &rpcMsg)
@@ -58,7 +60,7 @@ func waitForMessages(c *net.UDPConn) {
 					Msg("Failed to parse RPC options")
 			}
 
-			log.Debug().Str("Id", c.ID.String()).Str("Address", c.Address).Msg("Updating bucket")
+			log.Debug().Str("Id", c.ID.String()).Str("Address", c.Address.String()).Msg("Updating bucket")
 		} else {
 			log.Warn().Str("Error", err.Error()).Msg("Failed to deserialize message")
 		}

--- a/internal/udpsender/udpsender.go
+++ b/internal/udpsender/udpsender.go
@@ -1,28 +1,24 @@
 package udpsender
 
 import (
-	"net"
-	"strconv"
-
 	"github.com/rs/zerolog/log"
+	"kademlia/internal/address"
+	"net"
 )
 
 type UDPSender struct {
 	target *net.UDPAddr
 }
 
-func New(target string) UDPSender {
-	host, port, err := net.SplitHostPort(target)
+func New(target *address.Address) UDPSender {
+
+	port, err := target.GetPortAsInt()
 	if err != nil {
-		log.Error().Str("Target", target).Msgf("Failed to parse given target address: %s", err)
-	}
-	iport, err := strconv.Atoi(port)
-	if err != nil {
-		log.Error().Str("Port", port).Msgf("Failed to parse given string port to int: %s", err)
+		log.Error().Str("Address", target.String()).Msgf("Failed to parse given string port to int: %s", err)
 	}
 	return UDPSender{target: &net.UDPAddr{
-		IP:   net.ParseIP(host),
-		Port: iport,
+		IP:   net.ParseIP(target.GetHost()),
+		Port: port,
 	}}
 }
 


### PR DESCRIPTION
Address holds a host string and port string, it includes the net lib to split host and port from given address and also join them. I allows for the use of a env variable for port instead of hardcoding it in different classes

Closes #61 