### PR TITLE
Implement rpc pool

### DIFF
--- a/internal/commands/addcontact/addcontact_test.go
+++ b/internal/commands/addcontact/addcontact_test.go
@@ -2,6 +2,7 @@ package addcontact_test
 
 import (
 	// "fmt"
+	"kademlia/internal/address"
 	"kademlia/internal/commands/addcontact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/node"
@@ -40,7 +41,7 @@ func TestExecute(t *testing.T) {
 	var addcCmd *addcontact.AddContact
 
 	// should add the contact
-	node.KadNode.Init("127.0.0.1:1776")
+	node.KadNode.Init(address.New("127.0.0.1:1776"))
 	addcCmd = new(addcontact.AddContact)
 	id := kademliaid.NewRandomKademliaID().String()
 	addcCmd.ParseOptions([]string{id, "127.0.0.1:1776"})

--- a/internal/commands/getid/getid.go
+++ b/internal/commands/getid/getid.go
@@ -1,7 +1,7 @@
 package getid
 
 import (
-	"kademlia/internal/node"
+	"kademlia/internal/globals"
 
 	"github.com/rs/zerolog/log"
 )
@@ -12,7 +12,7 @@ type GetId struct {
 // getid returns the nodes kademlia ID
 func (g GetId) Execute() (string, error) {
 	log.Debug().Msg("Executing getid command")
-	return node.KadNode.Id.String(), nil
+	return globals.ID.String(), nil
 }
 
 func (g *GetId) ParseOptions(options []string) error {

--- a/internal/commands/getid/getid_test.go
+++ b/internal/commands/getid/getid_test.go
@@ -2,8 +2,8 @@ package getid_test
 
 import (
 	"kademlia/internal/commands/getid"
+	"kademlia/internal/globals"
 	"kademlia/internal/kademliaid"
-	"kademlia/internal/node"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +24,7 @@ func TestExecute(t *testing.T) {
 
 	// should return the nodes ID
 	id := kademliaid.NewRandomKademliaID()
-	node.KadNode.Id = id
+	globals.ID = id
 	getidCmd = new(getid.GetId)
 	res, err := getidCmd.Execute()
 	assert.Nil(t, err)

--- a/internal/commands/initnode/initnode.go
+++ b/internal/commands/initnode/initnode.go
@@ -3,10 +3,8 @@ package initnode
 import (
 	"errors"
 	"kademlia/internal/address"
-	"kademlia/internal/contact"
-	"kademlia/internal/kademliaid"
+	"kademlia/internal/globals"
 	"kademlia/internal/node"
-	"kademlia/internal/routingtable"
 
 	"github.com/rs/zerolog/log"
 )
@@ -21,15 +19,10 @@ func (i *InitNode) Execute() (string, error) {
 	log.Debug().Msg("Executing init command")
 	log.Info().Msg("Initializing node...")
 
-	id := kademliaid.NewRandomKademliaID()
 	adr := address.New(i.Address)
-	me := contact.NewContact(id, &adr)
-	node.KadNode = node.Node{
-		Id:           id,
-		RoutingTable: routingtable.NewRoutingTable(me),
-	}
+	node.KadNode.Init(adr)
 
-	log.Info().Str("NodeID", id.String()).Msg("ID assigned")
+	log.Info().Str("NodeID", globals.ID.String()).Msg("ID assigned")
 
 	return "Node initialized", nil
 }

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -1,0 +1,9 @@
+package globals
+
+import (
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/rpcpool"
+)
+
+var ID *kademliaid.KademliaID = kademliaid.NewRandomKademliaID()
+var RPCPool *rpcpool.RPCPool = rpcpool.New()

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -2,12 +2,14 @@ package network
 
 import (
 	"fmt"
-	"github.com/rs/zerolog/log"
+
 	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/rpc"
 	"kademlia/internal/udpsender"
+
+	"github.com/rs/zerolog/log"
 )
 
 var Net Network
@@ -45,8 +47,12 @@ func (network *Network) SendFindContactMessage(contact *contact.Contact) {
 	// TODO
 }
 
-func (network *Network) SendFindDataMessage(hash string) {
-	// TODO
+func (network *Network) SendFindDataMessage(rpc rpc.RPC) {
+	//TODO
+}
+
+func (network *Network) SendFindDataRespMessage(target *address.Address, rpcId *kademliaid.KademliaID) {
+	//TODO
 }
 
 func (network *Network) SendStoreMessage(target *address.Address, data []byte) {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -4,14 +4,13 @@ import (
 	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/datastore"
-	"kademlia/internal/kademliaid"
+	"kademlia/internal/globals"
 	"kademlia/internal/routingtable"
 
 	"github.com/rs/zerolog/log"
 )
 
 type Node struct {
-	Id           *kademliaid.KademliaID
 	RoutingTable *routingtable.RoutingTable
 }
 
@@ -19,12 +18,10 @@ var KadNode Node
 
 // Initialize the node by generating a NodeID and creating a new routing table
 // containing itself as a contact
-func (node *Node) Init(target string) {
-	id := kademliaid.NewRandomKademliaID()
-	adr := address.New(target)
+func (node *Node) Init(address address.Address) {
+	me := contact.NewContact(globals.ID, &address)
 	KadNode = Node{
-		Id:           id,
-		RoutingTable: routingtable.NewRoutingTable(contact.NewContact(id, &adr)),
+		RoutingTable: routingtable.NewRoutingTable(me),
 	}
 }
 

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/node"
 	"testing"
 
@@ -8,9 +9,9 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	node.KadNode.Init("address")
+	addr := address.New("address")
+	node.KadNode.Init(addr)
 
 	// should initialize the node variables
-	assert.NotNil(t, node.KadNode.Id)
 	assert.NotNil(t, node.KadNode.RoutingTable)
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -3,10 +3,11 @@ package rpc
 import (
 	"errors"
 	"fmt"
-	"kademlia/internal/address"
-	"kademlia/internal/kademliaid"
-	"kademlia/internal/node"
 	"strings"
+
+	"kademlia/internal/address"
+	"kademlia/internal/globals"
+	"kademlia/internal/kademliaid"
 
 	"github.com/rs/zerolog/log"
 )
@@ -23,7 +24,20 @@ type Sender interface {
 }
 
 func New(content string, target *address.Address) RPC {
-	return RPC{SenderId: node.KadNode.Id, RPCId: kademliaid.NewRandomKademliaID(), Content: content, Target: target}
+	return RPC{SenderId: globals.ID, RPCId: kademliaid.NewRandomKademliaID(), Content: content, Target: target}
+}
+
+// Constructs a new RPC with a given rpcID.
+//
+// Useful for creating new RPC's that are responses to previous RPCs, and thus
+// should use the same RPCId.
+func NewWithID(content string, target *address.Address, rpcId *kademliaid.KademliaID) RPC {
+	return RPC{
+		SenderId: globals.ID,
+		RPCId:    rpcId,
+		Content:  content,
+		Target:   target,
+	}
 }
 
 // Sends the message using the send function

--- a/internal/rpcpool/rpcpool.go
+++ b/internal/rpcpool/rpcpool.go
@@ -1,0 +1,32 @@
+package rpcpool
+
+import (
+	"kademlia/internal/kademliaid"
+)
+
+type Entry struct {
+	Channel chan string
+	rpcID   *kademliaid.KademliaID
+}
+
+type RPCPool struct {
+	entries map[kademliaid.KademliaID]*Entry
+}
+
+func New() *RPCPool {
+	return &RPCPool{
+		entries: make(map[kademliaid.KademliaID]*Entry),
+	}
+}
+
+func (pool *RPCPool) Add(rpcID *kademliaid.KademliaID) {
+	pool.entries[*rpcID] = &Entry{rpcID: rpcID, Channel: make(chan string)}
+}
+
+func (pool *RPCPool) GetEntry(rpcId *kademliaid.KademliaID) *Entry {
+	return pool.entries[*rpcId]
+}
+
+func (pool *RPCPool) Delete(rpcId *kademliaid.KademliaID) {
+	delete(pool.entries, *rpcId)
+}


### PR DESCRIPTION
Moves the node's ID to global scope (this will be reverted in a new pull request soon).