### PR TITLE
Don't use global variables

### DIFF
--- a/cmd/kademlia/kademlia.go
+++ b/cmd/kademlia/kademlia.go
@@ -3,6 +3,7 @@ package main
 import (
 	"kademlia/internal/command/listener"
 	"kademlia/internal/logger"
+	"kademlia/internal/node"
 	"kademlia/internal/udplistener"
 	"net"
 	"os"
@@ -36,6 +37,8 @@ func main() {
 	}
 	log.Info().Str("Hostname", host).Str("IP", ip).Msg("Starting node...")
 
-	go cmdlistener.Listen()
-	udplistener.Listen(ip, 1776)
+	node := node.Node{}
+
+	go cmdlistener.Listen(&node)
+	udplistener.Listen(ip, 1776, &node)
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,7 +1,11 @@
 package command
 
+import (
+	"kademlia/internal/node"
+)
+
 type Command interface {
-	Execute() (string, error)
+	Execute(node *node.Node) (string, error)
 
 	// Parse the options (i.e. words after command) and set related fields in
 	// the struct

--- a/internal/command/listener/listener.go
+++ b/internal/command/listener/listener.go
@@ -1,10 +1,12 @@
 package cmdlistener
 
 import (
-	"github.com/rs/zerolog/log"
 	"kademlia/internal/command/parser"
+	"kademlia/internal/node"
 	"net"
 	"os"
+
+	"github.com/rs/zerolog/log"
 )
 
 // Clears the socket at socketAddress
@@ -21,7 +23,7 @@ func ClearSocket(socketAddress string) {
 	}
 }
 
-func respond(c net.Conn) {
+func respond(c net.Conn, node *node.Node) {
 	buf := make([]byte, 512)
 	nr, err := c.Read(buf)
 	if err != nil {
@@ -36,7 +38,7 @@ func respond(c net.Conn) {
 	// Execute command
 	var executionResult string
 	if command != nil {
-		executionResult, err = command.Execute()
+		executionResult, err = command.Execute(node)
 
 		// Write response
 		if err == nil {
@@ -51,7 +53,7 @@ func respond(c net.Conn) {
 	c.Close()
 }
 
-func Listen() {
+func Listen(node *node.Node) {
 	const socketAddress = "/tmp/echo.sock"
 
 	ClearSocket(socketAddress)
@@ -67,7 +69,7 @@ func Listen() {
 		c, err := l.Accept()
 		if err == nil {
 			log.Info().Str("Address", socketAddress).Msg("Received message from socket")
-			go respond(c)
+			go respond(c, node)
 		} else {
 			log.Error().Msgf("Listener failed to accept: %s", err)
 		}

--- a/internal/commands/addcontact/addcontact.go
+++ b/internal/commands/addcontact/addcontact.go
@@ -16,10 +16,10 @@ type AddContact struct {
 	Address string
 }
 
-func (a *AddContact) Execute() (string, error) {
+func (a *AddContact) Execute(node *node.Node) (string, error) {
 	log.Debug().Msg("Executing addcontact command")
 	adr := address.New(a.Address)
-	node.KadNode.RoutingTable.AddContact(contact.NewContact(kademliaid.FromString(a.Id), &adr))
+	node.RoutingTable.AddContact(contact.NewContact(kademliaid.FromString(a.Id), &adr))
 	return "Contact added: " + fmt.Sprint(adr.String()), nil
 }
 

--- a/internal/commands/addcontact/addcontact_test.go
+++ b/internal/commands/addcontact/addcontact_test.go
@@ -41,11 +41,12 @@ func TestExecute(t *testing.T) {
 	var addcCmd *addcontact.AddContact
 
 	// should add the contact
-	node.KadNode.Init(address.New("127.0.0.1:1776"))
+	node := node.Node{}
+	node.Init(address.New("127.0.0.1:1776"))
 	addcCmd = new(addcontact.AddContact)
 	id := kademliaid.NewRandomKademliaID().String()
 	addcCmd.ParseOptions([]string{id, "127.0.0.1:1776"})
-	res, err := addcCmd.Execute()
+	res, err := addcCmd.Execute(&node)
 	assert.Equal(t, "Contact added: 127.0.0.1:1776", res)
 	assert.Nil(t, err)
 }

--- a/internal/commands/exit/exit.go
+++ b/internal/commands/exit/exit.go
@@ -1,14 +1,16 @@
 package exit
 
 import (
-	"github.com/rs/zerolog/log"
+	"kademlia/internal/node"
 	"os"
+
+	"github.com/rs/zerolog/log"
 )
 
 type Exit struct {
 }
 
-func (e Exit) Execute() (string, error) {
+func (e Exit) Execute(node *node.Node) (string, error) {
 	log.Debug().Msg("Executing exit command")
 	log.Info().Msg("Node exiting...")
 	os.Exit(0)

--- a/internal/commands/get/get.go
+++ b/internal/commands/get/get.go
@@ -2,8 +2,8 @@ package get
 
 import (
 	"errors"
-	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
 
 	"github.com/rs/zerolog/log"
 )
@@ -12,11 +12,11 @@ type Get struct {
 	hash kademliaid.KademliaID
 }
 
-func (get *Get) Execute() (string, error) {
+func (get *Get) Execute(node *node.Node) (string, error) {
 	log.Debug().Msg("Executing get command")
 
 	// Check local storage
-	value := datastore.Store.Get(get.hash)
+	value := node.DataStore.Get(get.hash)
 	if value == "" {
 		log.Debug().Str("Key", get.hash.String()).Msg("Value not found locally")
 

--- a/internal/commands/get/get_test.go
+++ b/internal/commands/get/get_test.go
@@ -1,9 +1,10 @@
 package get_test
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/commands/get"
-	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,19 +30,21 @@ func TestParseOption(t *testing.T) {
 func TestExecute(t *testing.T) {
 	var g get.Get
 	var res string
+	node := node.Node{}
+	node.Init(address.New(""))
 
 	// should not return a value if it does not exist
 	g = *new(get.Get)
 	g.ParseOptions([]string{"non existent hash"})
-	res, _ = g.Execute()
+	res, _ = g.Execute(&node)
 	assert.Equal(t, res, "Key not found")
 
 	//should return the value if it does exist
 	g = *new(get.Get)
 	message := "some message"
-	datastore.Store.Insert(message)
+	node.DataStore.Insert(message)
 	id := kademliaid.NewKademliaID(&message)
 	g.ParseOptions([]string{(&id).String()})
-	res, _ = g.Execute()
+	res, _ = g.Execute(&node)
 	assert.Equal(t, res, "some message")
 }

--- a/internal/commands/getcontacts/getcontacts.go
+++ b/internal/commands/getcontacts/getcontacts.go
@@ -7,9 +7,9 @@ import (
 
 type GetContacts struct{}
 
-func (g *GetContacts) Execute() (string, error) {
+func (g *GetContacts) Execute(node *node.Node) (string, error) {
 	log.Debug().Msg("Executing getcontacts command")
-	return node.KadNode.RoutingTable.GetContacts(), nil
+	return node.RoutingTable.GetContacts(), nil
 }
 
 func (g *GetContacts) ParseOptions(options []string) error {

--- a/internal/commands/getcontacts/getcontacts_test.go
+++ b/internal/commands/getcontacts/getcontacts_test.go
@@ -2,6 +2,7 @@ package getcontacts_test
 
 import (
 	"kademlia/internal/commands/getcontacts"
+	"kademlia/internal/node"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,8 +21,8 @@ func TestExecute(t *testing.T) {
 	var getcsCmd *getcontacts.GetContacts
 
 	// should return message informing that the routingtable is empty
-	res, err := getcsCmd.Execute()
+	node := node.Node{}
+	res, err := getcsCmd.Execute(&node)
 	assert.Equal(t, "Empty! Please, populate the routingtable...", res)
 	assert.Nil(t, err)
-
 }

--- a/internal/commands/getid/getid.go
+++ b/internal/commands/getid/getid.go
@@ -1,7 +1,7 @@
 package getid
 
 import (
-	"kademlia/internal/globals"
+	"kademlia/internal/node"
 
 	"github.com/rs/zerolog/log"
 )
@@ -10,9 +10,9 @@ type GetId struct {
 }
 
 // getid returns the nodes kademlia ID
-func (g GetId) Execute() (string, error) {
+func (g GetId) Execute(node *node.Node) (string, error) {
 	log.Debug().Msg("Executing getid command")
-	return globals.ID.String(), nil
+	return node.ID.String(), nil
 }
 
 func (g *GetId) ParseOptions(options []string) error {

--- a/internal/commands/getid/getid_test.go
+++ b/internal/commands/getid/getid_test.go
@@ -2,8 +2,9 @@ package getid_test
 
 import (
 	"kademlia/internal/commands/getid"
-	"kademlia/internal/globals"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"kademlia/internal/nodedata"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,9 +25,9 @@ func TestExecute(t *testing.T) {
 
 	// should return the nodes ID
 	id := kademliaid.NewRandomKademliaID()
-	globals.ID = id
+	node := node.Node{NodeData: nodedata.NodeData{ID: id}}
 	getidCmd = new(getid.GetId)
-	res, err := getidCmd.Execute()
+	res, err := getidCmd.Execute(&node)
 	assert.Nil(t, err)
 	assert.Equal(t, id.String(), res)
 }

--- a/internal/commands/initnode/initnode.go
+++ b/internal/commands/initnode/initnode.go
@@ -3,7 +3,6 @@ package initnode
 import (
 	"errors"
 	"kademlia/internal/address"
-	"kademlia/internal/globals"
 	"kademlia/internal/node"
 
 	"github.com/rs/zerolog/log"
@@ -15,14 +14,14 @@ type InitNode struct {
 
 // Initialize the node by generating a NodeID and creating a new routing table
 // containing itself as a contact
-func (i *InitNode) Execute() (string, error) {
+func (i *InitNode) Execute(node *node.Node) (string, error) {
 	log.Debug().Msg("Executing init command")
 	log.Info().Msg("Initializing node...")
 
 	adr := address.New(i.Address)
-	node.KadNode.Init(adr)
+	node.Init(adr)
 
-	log.Info().Str("NodeID", globals.ID.String()).Msg("ID assigned")
+	log.Info().Str("NodeID", node.ID.String()).Msg("ID assigned")
 
 	return "Node initialized", nil
 }

--- a/internal/commands/initnode/initnode_test.go
+++ b/internal/commands/initnode/initnode_test.go
@@ -1,8 +1,10 @@
 package initnode_test
 
 import (
-	"kademlia/internal/commands/initnode"
 	"testing"
+
+	"kademlia/internal/commands/initnode"
+	"kademlia/internal/node"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,7 +35,8 @@ func TestExecute(t *testing.T) {
 	// should initialize the node
 	initCmd = new(initnode.InitNode)
 	initCmd.ParseOptions([]string{"address"})
-	res, err := initCmd.Execute()
+	node := node.Node{}
+	res, err := initCmd.Execute(&node)
 	assert.Equal(t, "Node initialized", res)
 	assert.Nil(t, err)
 }

--- a/internal/commands/message/message.go
+++ b/internal/commands/message/message.go
@@ -3,6 +3,7 @@ package message
 import (
 	"errors"
 	"kademlia/internal/address"
+	"kademlia/internal/node"
 	kademliaMessage "kademlia/internal/rpc"
 	"kademlia/internal/udpsender"
 
@@ -14,10 +15,10 @@ type Message struct {
 	Content string
 }
 
-func (msg Message) Execute() (string, error) {
+func (msg Message) Execute(node *node.Node) (string, error) {
 	log.Debug().Str("Target", msg.Target).Msg("Executing message command")
 	adr := address.New(msg.Target)
-	message := kademliaMessage.New(msg.Content, &adr)
+	message := kademliaMessage.New(node.ID, msg.Content, &adr)
 	udpSender := udpsender.New(&adr)
 	err := message.Send(udpSender)
 

--- a/internal/commands/ping/ping.go
+++ b/internal/commands/ping/ping.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"kademlia/internal/address"
 	"kademlia/internal/network"
+	"kademlia/internal/node"
 
 	"github.com/rs/zerolog/log"
 )
@@ -12,10 +13,10 @@ type Ping struct {
 	Target string
 }
 
-func (p Ping) Execute() (string, error) {
+func (p Ping) Execute(node *node.Node) (string, error) {
 	log.Debug().Str("Target", p.Target).Msg("Executing ping command")
 	adr := address.New(p.Target)
-	network.Net.SendPingMessage(&adr)
+	network.Net.SendPingMessage(node.ID, &adr)
 
 	return "Ping sent!", nil
 

--- a/internal/commands/put/put.go
+++ b/internal/commands/put/put.go
@@ -14,17 +14,18 @@ type Put struct {
 	fileContent string
 }
 
-func (put *Put) Execute() (string, error) {
+func (put *Put) Execute(node *node.Node) (string, error) {
+
 	log.Debug().Msg("Executing put command")
 	k := 20 //TODO: Use constant
 	key := kademliaid.NewKademliaID(&put.fileContent)
-	closestNodes := node.KadNode.RoutingTable.FindClosestContacts(&key, k)
+	closestNodes := node.RoutingTable.FindClosestContacts(&key, k)
 
-	node.KadNode.Store(&put.fileContent)
+	node.Store(&put.fileContent)
 
 	// Send STORE RPCs
 	for _, node := range closestNodes {
-		network.Net.SendStoreMessage(node.Address, []byte(put.fileContent))
+		network.Net.SendStoreMessage(node.ID, node.Address, []byte(put.fileContent))
 	}
 
 	return "", nil

--- a/internal/commands/storage/storage.go
+++ b/internal/commands/storage/storage.go
@@ -1,17 +1,17 @@
 package storage
 
 import (
-	"kademlia/internal/datastore"
+	"kademlia/internal/node"
 
 	"github.com/rs/zerolog/log"
 )
 
 type Storage struct{}
 
-func (d Storage) Execute() (string, error) {
+func (d Storage) Execute(node *node.Node) (string, error) {
 	log.Debug().Msg("Executing storage command")
 
-	result := datastore.Store.EntriesAsString()
+	result := node.DataStore.EntriesAsString()
 
 	return result, nil
 }

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -52,5 +52,3 @@ func (d *DataStore) EntriesAsString() string {
 	}
 	return s
 }
-
-var Store = New()

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -1,9 +1,0 @@
-package globals
-
-import (
-	"kademlia/internal/kademliaid"
-	"kademlia/internal/rpcpool"
-)
-
-var ID *kademliaid.KademliaID = kademliaid.NewRandomKademliaID()
-var RPCPool *rpcpool.RPCPool = rpcpool.New()

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -17,10 +17,10 @@ var Net Network
 type Network struct{}
 
 // SendPongMessage replies a "PONG" message to the remote "pinger" address
-func (network *Network) SendPongMessage(target *address.Address, id *kademliaid.KademliaID) {
+func (network *Network) SendPongMessage(senderId *kademliaid.KademliaID, target *address.Address, id *kademliaid.KademliaID) {
 
 	log.Debug().Str("Address", target.String()).Msg("Sending PONG to address")
-	rpc := rpc.New("PONG", target)
+	rpc := rpc.New(senderId, "PONG", target)
 	rpc.RPCId = id
 	udpSender := udpsender.New(target)
 
@@ -32,8 +32,8 @@ func (network *Network) SendPongMessage(target *address.Address, id *kademliaid.
 }
 
 // SendPingMessage sends a "PING" message to a remote address
-func (network *Network) SendPingMessage(target *address.Address) {
-	rpc := rpc.New("PING", target)
+func (network *Network) SendPingMessage(senderId *kademliaid.KademliaID, target *address.Address) {
+	rpc := rpc.New(senderId, "PING", target)
 	udpSender := udpsender.New(target)
 
 	err := rpc.Send(udpSender)
@@ -55,9 +55,9 @@ func (network *Network) SendFindDataRespMessage(target *address.Address, rpcId *
 	//TODO
 }
 
-func (network *Network) SendStoreMessage(target *address.Address, data []byte) {
+func (network *Network) SendStoreMessage(senderId *kademliaid.KademliaID, target *address.Address, data []byte) {
 	log.Debug().Str("Target", target.String()).Msg("Sending store message")
-	rpc := rpc.New(fmt.Sprintf("%s %s", "STORE", data), target)
+	rpc := rpc.New(senderId, fmt.Sprintf("%s %s", "STORE", data), target)
 	udpSender := udpsender.New(target)
 	err := rpc.Send(udpSender)
 

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -9,9 +9,10 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	addr := address.New("address")
-	node.KadNode.Init(addr)
+	node := node.Node{}
+	adr := address.New("address")
+	node.Init(adr)
 
 	// should initialize the node variables
-	assert.NotNil(t, node.KadNode.RoutingTable)
+	assert.NotNil(t, node.RoutingTable)
 }

--- a/internal/nodedata/nodedata.go
+++ b/internal/nodedata/nodedata.go
@@ -1,0 +1,15 @@
+package nodedata
+
+import (
+	"kademlia/internal/datastore"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/routingtable"
+	"kademlia/internal/rpcpool"
+)
+
+type NodeData struct {
+	RoutingTable *routingtable.RoutingTable
+	DataStore    datastore.DataStore
+	ID           *kademliaid.KademliaID
+	RPCPool      *rpcpool.RPCPool
+}

--- a/internal/routingtable/routingtable_test.go
+++ b/internal/routingtable/routingtable_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestGetContacts(t *testing.T) {
+	node := node.Node{}
 	// should return message informing that the routingtable is empty
-	assert.Equal(t, "Empty! Please, populate the routingtable...", node.KadNode.RoutingTable.GetContacts())
+	assert.Equal(t, "Empty! Please, populate the routingtable...", node.RoutingTable.GetContacts())
 
 }

--- a/internal/rpc/parser/parser_test.go
+++ b/internal/rpc/parser/parser_test.go
@@ -18,36 +18,37 @@ import (
 func TestParseRPC(t *testing.T) {
 	adr := address.New("127.0.0.1:1776")
 	c := contact.NewContact(kademliaid.NewRandomKademliaID(), &adr)
+	senderId := kademliaid.NewRandomKademliaID()
 	var r rpc.RPC
 	var rpcCmd rpccommand.RPCCommand
 	var err error
 
 	//Should be able to parse a PING rpc
-	r = rpc.New("PING", &adr)
+	r = rpc.New(senderId, "PING", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, ping.Ping{}, rpcCmd)
 
 	//Should be able to parse a PONG rpc
-	r = rpc.New("PONG", &adr)
+	r = rpc.New(senderId, "PONG", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, pong.Pong{}, rpcCmd)
 
 	//Should be able to parse a STORE rpc
-	r = rpc.New("STORE", &adr)
+	r = rpc.New(senderId, "STORE", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, &store.Store{}, rpcCmd)
 
 	//Should not parse an unknown RPC
-	r = rpc.New("HELLO", &adr)
+	r = rpc.New(senderId, "HELLO", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.EqualError(t, err, "Received unknown RPC HELLO")
 	assert.Nil(t, rpcCmd)
 
 	//Should not parse empty string
-	r = rpc.New("", &adr)
+	r = rpc.New(senderId, "", &adr)
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "Missing RPC name")

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"kademlia/internal/address"
-	"kademlia/internal/globals"
 	"kademlia/internal/kademliaid"
 
 	"github.com/rs/zerolog/log"
@@ -23,17 +22,17 @@ type Sender interface {
 	Send(string) error
 }
 
-func New(content string, target *address.Address) RPC {
-	return RPC{SenderId: globals.ID, RPCId: kademliaid.NewRandomKademliaID(), Content: content, Target: target}
+func New(senderId *kademliaid.KademliaID, content string, target *address.Address) RPC {
+	return RPC{SenderId: senderId, RPCId: kademliaid.NewRandomKademliaID(), Content: content, Target: target}
 }
 
 // Constructs a new RPC with a given rpcID.
 //
 // Useful for creating new RPC's that are responses to previous RPCs, and thus
 // should use the same RPCId.
-func NewWithID(content string, target *address.Address, rpcId *kademliaid.KademliaID) RPC {
+func NewWithID(senderId *kademliaid.KademliaID, content string, target *address.Address, rpcId *kademliaid.KademliaID) RPC {
 	return RPC{
-		SenderId: globals.ID,
+		SenderId: senderId,
 		RPCId:    rpcId,
 		Content:  content,
 		Target:   target,

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -25,7 +25,8 @@ func (m *SenderMock) Send(data string) error {
 func TestNew(t *testing.T) {
 	var content, target = "some message", "127.0.0.1:1337"
 	adr := address.New(target)
-	rpc := rpc.New(content, &adr)
+	senderId := kademliaid.NewRandomKademliaID()
+	rpc := rpc.New(senderId, content, &adr)
 
 	assert.Equal(t, rpc.Target, &adr)
 	assert.Equal(t, rpc.Content, content)

--- a/internal/rpccommand/rpccommand.go
+++ b/internal/rpccommand/rpccommand.go
@@ -1,6 +1,10 @@
 package rpccommand
 
+import (
+	"kademlia/internal/node"
+)
+
 type RPCCommand interface {
-	Execute()
+	Execute(node *node.Node)
 	ParseOptions(options *[]string) error
 }

--- a/internal/rpccommands/ping/ping.go
+++ b/internal/rpccommands/ping/ping.go
@@ -4,6 +4,7 @@ import (
 	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/network"
+	"kademlia/internal/node"
 )
 
 type Ping struct {
@@ -15,9 +16,9 @@ func New(senderAddress *address.Address, rpcId *kademliaid.KademliaID) Ping {
 	return Ping{senderAddress: senderAddress, rpcId: rpcId}
 }
 
-func (ping Ping) Execute() {
+func (ping Ping) Execute(node *node.Node) {
 	// Respond with pong
-	network.Net.SendPongMessage(ping.senderAddress, ping.rpcId)
+	network.Net.SendPongMessage(node.ID, ping.senderAddress, ping.rpcId)
 }
 
 func (ping Ping) ParseOptions(options *[]string) error {

--- a/internal/rpccommands/pong/pong.go
+++ b/internal/rpccommands/pong/pong.go
@@ -1,12 +1,14 @@
 package pong
 
+import "kademlia/internal/node"
+
 type Pong struct{}
 
 func New() Pong {
 	return Pong{}
 }
 
-func (pong Pong) Execute() {
+func (pong Pong) Execute(node *node.Node) {
 	// Pong does nothing
 }
 

--- a/internal/rpccommands/store/store.go
+++ b/internal/rpccommands/store/store.go
@@ -10,8 +10,8 @@ type Store struct {
 	fileContent string
 }
 
-func (store *Store) Execute() {
-	node.KadNode.Store(&store.fileContent)
+func (store *Store) Execute(node *node.Node) {
+	node.Store(&store.fileContent)
 }
 
 func (store *Store) ParseOptions(options *[]string) error {

--- a/internal/rpccommands/store/store_test.go
+++ b/internal/rpccommands/store/store_test.go
@@ -1,8 +1,9 @@
 package store_test
 
 import (
-	"kademlia/internal/datastore"
+	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
 	"kademlia/internal/rpccommands/store"
 	"reflect"
 	"testing"
@@ -20,8 +21,10 @@ func TestExecute(t *testing.T) {
 	fileContent := "this is some file content"
 	err = s.ParseOptions(&options)
 	assert.NoError(t, err)
-	s.Execute()
-	assert.Equal(t, fileContent, datastore.Store.Get(kademliaid.NewKademliaID(&fileContent)))
+	node := node.Node{}
+	node.Init(address.New(""))
+	s.Execute(&node)
+	assert.Equal(t, fileContent, node.DataStore.Get(kademliaid.NewKademliaID(&fileContent)))
 }
 
 func TestParseOptions(t *testing.T) {


### PR DESCRIPTION
This removes the global node variable and instead a local object is
created an is passed around.
Also the node's id, datastore and rpc pool has been moved into the node
struct.
RPCs's sender ids are no longer attached automatically when creating the RPC, instead RPCs are created via the node which attaches its id .