### PR TITLE
Implement network joining and FIND_NODE RPC

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,11 +7,11 @@ services:
       dockerfile: dev.Dockerfile
     deploy:
       mode: replicated
-      replicas: 5  
-#        resources:
-#           limits:
-#              cpus: "0.1"
-#              memory: 50M
+      replicas: 5
+      #        resources:
+      #           limits:
+      #              cpus: "0.1"
+      #              memory: 50M
       restart_policy:
         condition: on-failure
         delay: 5s
@@ -23,8 +23,8 @@ services:
       - ./:/kademlia
     environment:
       - LOG_LEVEL=${LOG_LEVEL:-debug}
-      - K=20
-      - ALPHA=3
-      
+      - K=5
+      - ALPHA=1
+
 networks:
   kademlia_dev_network:

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -57,6 +57,23 @@ func (bucket *Bucket) GetContactAndCalcDistance(target *KademliaID) []Contact {
 	return contacts
 }
 
+// GetContactAndCalcDistance returns an array of Contacts where the distance
+// has already been calculated. This array will never contain a contact with
+// the same nodeID as the requestorID.
+func (bucket *Bucket) GetContactAndCalcDistanceNoRequestor(target *KademliaID, requestorID *KademliaID) []Contact {
+
+	var contacts []Contact
+
+	for elt := bucket.list.Front(); elt != nil; elt = elt.Next() {
+		contact := elt.Value.(Contact)
+		if contact.ID != requestorID {
+			contact.CalcDistance(target)
+			contacts = append(contacts, contact)
+		}
+	}
+	return contacts
+}
+
 // Len return the size of the bucket
 func (bucket *Bucket) Len() int {
 	return bucket.list.Len()

--- a/internal/command/parser/parser.go
+++ b/internal/command/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	"kademlia/internal/commands/getcontacts"
 	"kademlia/internal/commands/getid"
 	"kademlia/internal/commands/initnode"
+	"kademlia/internal/commands/join"
 	"kademlia/internal/commands/message"
 	"kademlia/internal/commands/ping"
 	"kademlia/internal/commands/put"
@@ -45,6 +46,8 @@ func ParseCmd(s string) Command {
 		command = new(initnode.InitNode)
 	case "put":
 		command = new(put.Put)
+	case "join":
+		command = new(join.Join)
 	default:
 		log.Error().Str("command", cmd).Msg("Received unknown command")
 		return nil

--- a/internal/command/parser/parser_test.go
+++ b/internal/command/parser/parser_test.go
@@ -59,6 +59,10 @@ func TestParseCmd(t *testing.T) {
 	cmd = cmdparser.ParseCmd("put")
 	assert.Nil(t, cmd)
 
+	// should be able to parse a join command
+	cmd = cmdparser.ParseCmd("join")
+	assert.NotNil(t, cmd)
+
 	//should return nil if an invalid command was passed
 	cmd = cmdparser.ParseCmd("non-existent command")
 	assert.Nil(t, cmd)

--- a/internal/commands/join/join.go
+++ b/internal/commands/join/join.go
@@ -1,0 +1,24 @@
+package join
+
+import (
+	"kademlia/internal/node"
+
+	"github.com/rs/zerolog/log"
+)
+
+type Join struct {
+}
+
+func (j *Join) Execute(node *node.Node) (string, error) {
+	log.Debug().Msg("Executing join command")
+	node.JoinNetwork()
+	return "Joined network on known node", nil
+}
+
+func (j *Join) ParseOptions(options []string) error {
+	return nil
+}
+
+func (j *Join) PrintUsage() {
+	log.Info().Msg("Usage: join")
+}

--- a/internal/commands/put/put.go
+++ b/internal/commands/put/put.go
@@ -16,14 +16,15 @@ type Put struct {
 }
 
 func (put *Put) Execute(node *node.Node) (string, error) {
-
 	log.Debug().Msg("Executing put command")
+
 	k, err := strconv.Atoi(os.Getenv("K"))
 	if err != nil {
 		log.Error().Msgf("Failed to convert env variable K from string to int: %s", err)
 	}
+
 	key := kademliaid.NewKademliaID(&put.fileContent)
-	closestNodes := node.RoutingTable.FindClosestContacts(&key, k)
+	closestNodes := node.FindKClosest(&key, nil, k)
 
 	node.Store(&put.fileContent)
 

--- a/internal/contact/contact.go
+++ b/internal/contact/contact.go
@@ -1,10 +1,12 @@
 package contact
 
 import (
+	"errors"
 	"fmt"
 	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
 	"sort"
+	"strings"
 )
 
 func Myprint() {
@@ -76,4 +78,29 @@ func (candidates *ContactCandidates) Swap(i, j int) {
 // the Contact at index j
 func (candidates *ContactCandidates) Less(i, j int) bool {
 	return candidates.contacts[i].Less(&candidates.contacts[j])
+}
+
+func (contact *Contact) serialize() string {
+	return fmt.Sprintf("%s!%s", contact.ID.String(), contact.Address.String())
+}
+
+func SerializeContacts(contacts []Contact) string {
+	s := ""
+	for i, contact := range contacts {
+		if i != len(contacts)-1 {
+			s += contact.serialize() + " "
+		} else {
+			s += contact.serialize()
+		}
+	}
+	return s
+}
+
+func Deserialize(s *string) (error, *Contact) {
+	fields := strings.Split(*s, "!")
+	if len(fields) == 0 || len(fields) == 1 {
+		return errors.New("blabla"), nil
+	}
+	adr := address.New(fields[1])
+	return nil, &Contact{ID: kademliaid.FromString(fields[0]), Address: adr}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,13 +1,20 @@
 package node
 
 import (
+	"fmt"
 	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/network"
 	"kademlia/internal/nodedata"
 	"kademlia/internal/routingtable"
 	"kademlia/internal/rpc"
+	"kademlia/internal/rpcpool"
+	"kademlia/internal/shortlist"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 )
@@ -26,12 +33,105 @@ func (node *Node) Init(address *address.Address) {
 			RoutingTable: routingtable.NewRoutingTable(me),
 			DataStore:    datastore.New(),
 			ID:           id,
+			RPCPool:      rpcpool.New(),
 		},
 	}
 }
 
-func (node *Node) LookupContact(target *contact.Contact) {
-	// TODO
+// Join performs a node lookup on itself to join the network and fill its
+// routing table
+// TODO: Should maybe check that the node knows of another node in the network.
+// This is not a problem as long as the init script is used.
+func (node *Node) JoinNetwork() {
+	node.LookupContact(node.RoutingTable.GetMe().ID)
+}
+
+// LookupContact searches for the contact with the specified key using the node
+// lookup algorithm.
+//
+// This implementation uses waitGroups to send alpha parallel FIND_NODE RPCs
+// and waits for the response of each request.
+// TODO: Ignore request after waiting X time and continue with next iteration
+func (node *Node) LookupContact(id *kademliaid.KademliaID) []contact.Contact {
+	alpha, err := strconv.Atoi(os.Getenv("ALPHA"))
+	if err != nil {
+		log.Error().Msgf("Failed to convert env variable ALPHA from string to int: %s", err)
+	}
+
+	sl := shortlist.NewShortlist(id, node.FindKClosest(id, nil, alpha))
+	channels := make([]chan string, alpha)
+
+	// iterative lookup until the search becomes stale
+	for {
+		closestSoFar := sl.Closest
+
+		// Probe alpha new nodes
+		numProbed := 0
+		rpcIds := []*kademliaid.KademliaID{}
+		for i := 0; i < sl.Len() && numProbed < alpha; i++ {
+			if !sl.Entries[i].Probed {
+				sl.Entries[i].Probed = true
+				rpc := node.NewRPC(fmt.Sprintf("%s %s", "FIND_NODE", id), sl.Entries[i].Contact.Address)
+				node.RPCPool.Add(rpc.RPCId)
+				entryRPC := node.RPCPool.GetEntry(rpc.RPCId)
+				rpcIds = append(rpcIds, rpc.RPCId)
+				channels[numProbed] = entryRPC.Channel
+				numProbed++
+				log.Trace().Str("Entry", fmt.Sprintf("%d", i)).Msg("Probing entry")
+				network.Net.SendFindContactMessage(&rpc)
+			}
+		}
+
+		// If no new nodes were probed this iteration the search is done
+		if numProbed == 0 {
+			log.Debug().Msg("Lookup Node became stale")
+			break
+		}
+
+		// Handle response from probed nodes
+		contacts := []*contact.Contact{}
+		for i := 0; i < numProbed; i++ {
+			log.Trace().Str("Channel", fmt.Sprintf("%d", i)).Str("rpcID", rpcIds[i].String()).Msg("Waiting for channel")
+			data := <-channels[i]
+			node.RPCPool.Delete(rpcIds[i]) // remove from rpc pool
+			log.Trace().Str("Channel", fmt.Sprintf("%d", i)).Str("Data", data).Msg("Received data from channel")
+
+			// parse contacts from response data
+			strContacts := strings.Split(data, " ")
+			for _, strContact := range strContacts {
+				err, contact := contact.Deserialize(&strContact)
+				if err != nil {
+					log.Print(err)
+					log.Warn().Msg("Received FIND_NODE_RESPONSE no contacts in FIND_NODE_RESPONSE")
+				} else {
+					log.Debug().Str("Contact", contact.String()).Msg("Received a contact")
+					contacts = append(contacts, contact)
+				}
+			}
+		}
+
+		// Update shortlist with new contacts recieved from responses
+		for _, contact := range contacts {
+			sl.Add(contact)
+		}
+
+		// Send FIND_NODE to all unqueried nodes in the shortlist and terminate
+		// the search since no node closer to the target was found this iteration
+		if sl.Closest == closestSoFar {
+			// TODO
+		}
+	}
+
+	log.Debug().Msg("Lookup Node became stale, returning k closest found")
+	log.Debug().Msg("k closest contacts found: ")
+	contacts := sl.GetContacts()
+	s := ""
+	for _, c := range contacts {
+		s += c.String() + "\n"
+	}
+	log.Debug().Msg(s)
+
+	return contacts
 }
 
 func (node *Node) NewRPC(content string, target *address.Address) rpc.RPC {
@@ -58,4 +158,10 @@ func (node *Node) LookupData(hash string) {
 func (node *Node) Store(value *string) {
 	log.Debug().Str("Value", *value).Msg("Storing value")
 	node.DataStore.Insert(*value)
+}
+
+// FindKClosest returns a list of candidates containing the k closest nodes
+// to the key being searched for (from the nodes own bucket(s))
+func (node *Node) FindKClosest(key *kademliaid.KademliaID, requestorID *kademliaid.KademliaID, k int) []contact.Contact {
+	return node.RoutingTable.FindClosestContacts(key, requestorID, k)
 }

--- a/internal/routingtable/routingtable_test.go
+++ b/internal/routingtable/routingtable_test.go
@@ -44,13 +44,14 @@ func TestAddContact(t *testing.T) {
 func TestFindClosestContacts(t *testing.T) {
 	node := node.Node{}
 	id := kademliaid.NewRandomKademliaID()
+	id2 := kademliaid.NewRandomKademliaID()
 	adr := address.New("127.0.0.1")
 	c := contact.NewContact(id, adr)
 	node.Init(adr)
 	node.RoutingTable.AddContact(c)
 
 	// should not return a index
-	assert.NotNil(t, node.RoutingTable.FindClosestContacts(id, 1))
+	assert.NotNil(t, node.RoutingTable.FindClosestContacts(id, id2, 1))
 
 }
 

--- a/internal/rpc/parser/parser.go
+++ b/internal/rpc/parser/parser.go
@@ -6,6 +6,8 @@ import (
 	"kademlia/internal/contact"
 	"kademlia/internal/rpc"
 	"kademlia/internal/rpccommand"
+	"kademlia/internal/rpccommands/findnode"
+	"kademlia/internal/rpccommands/findnoderesp"
 	"kademlia/internal/rpccommands/ping"
 	"kademlia/internal/rpccommands/pong"
 	"kademlia/internal/rpccommands/store"
@@ -15,7 +17,7 @@ import (
 )
 
 // Parses a rpc and returns a rpc command.
-func ParseRPC(sender *contact.Contact, rpc *rpc.RPC) (rpccommand.RPCCommand, error) {
+func ParseRPC(requestor *contact.Contact, rpc *rpc.RPC) (rpccommand.RPCCommand, error) {
 	fields := strings.Fields(rpc.Content)
 	if len(fields) == 0 {
 		return nil, errors.New("Missing RPC name")
@@ -27,13 +29,19 @@ func ParseRPC(sender *contact.Contact, rpc *rpc.RPC) (rpccommand.RPCCommand, err
 	switch identifier := fields[0]; identifier {
 	case "PING":
 		rpcLog.Msg("PING received")
-		cmd = ping.New(sender.Address, rpc.RPCId)
+		cmd = ping.New(requestor.Address, rpc.RPCId)
 	case "PONG":
 		rpcLog.Msg("PONG received")
 		cmd = pong.New()
 	case "STORE":
 		rpcLog.Msg("STORE received")
 		cmd = new(store.Store)
+	case "FIND_NODE":
+		rpcLog.Msg("FIND_NODE received")
+		cmd = findnode.New(requestor, rpc.RPCId)
+	case "FIND_NODE_RESPONSE":
+		rpcLog.Msg("FIND_NODE_RESPONSE received")
+		cmd = findenoderesp.New(rpc.RPCId)
 	default:
 		err = errors.New(fmt.Sprintf("Received unknown RPC %s", identifier))
 		cmd = nil

--- a/internal/rpc/parser/parser_test.go
+++ b/internal/rpc/parser/parser_test.go
@@ -5,8 +5,10 @@ import (
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/rpc"
-	rpcparser "kademlia/internal/rpc/parser"
+	"kademlia/internal/rpc/parser"
 	"kademlia/internal/rpccommand"
+	"kademlia/internal/rpccommands/findnode"
+	"kademlia/internal/rpccommands/findnoderesp"
 	"kademlia/internal/rpccommands/ping"
 	"kademlia/internal/rpccommands/pong"
 	"kademlia/internal/rpccommands/store"
@@ -40,6 +42,18 @@ func TestParseRPC(t *testing.T) {
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, &store.Store{}, rpcCmd)
+
+	// Should be able to parse a FIND_NODE RPC
+	r = rpc.New(senderId, "FIND_NODE", adr)
+	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
+	assert.Nil(t, err)
+	assert.IsType(t, &findnode.FindNode{}, rpcCmd)
+
+	// Should be able to parse a FIND_NODE_RESPONSE RPC
+	r = rpc.New(senderId, "FIND_NODE_RESPONSE", adr)
+	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
+	assert.Nil(t, err)
+	assert.IsType(t, &findenoderesp.FindNodeResp{}, rpcCmd)
 
 	//Should not parse an unknown RPC
 	r = rpc.New(senderId, "HELLO", adr)

--- a/internal/rpccommands/findnode/findnode.go
+++ b/internal/rpccommands/findnode/findnode.go
@@ -1,0 +1,45 @@
+package findnode
+
+import (
+	"errors"
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/network"
+	"kademlia/internal/node"
+	"os"
+	"strconv"
+
+	"github.com/rs/zerolog/log"
+)
+
+type FindNode struct {
+	id        *string
+	requestor *contact.Contact
+	rpcId     *kademliaid.KademliaID
+}
+
+func New(requestor *contact.Contact, rpcId *kademliaid.KademliaID) *FindNode {
+	return &FindNode{requestor: requestor, rpcId: rpcId}
+}
+
+func (fn *FindNode) Execute(node *node.Node) {
+	log.Trace().Msg("Executing FIND_NODE RPC")
+
+	k, err := strconv.Atoi(os.Getenv("K"))
+	if err != nil {
+		log.Error().Msgf("Failed to convert env variable ALPHA from string to int: %s", err)
+	}
+
+	// Respond with k closest nodes to the key
+	kClosest := node.FindKClosest(kademliaid.FromString(*fn.id), fn.requestor.ID, k)
+	content := contact.SerializeContacts(kClosest)
+	network.Net.SendFindContactRespMessage(node.ID, fn.requestor.Address, fn.rpcId, &content)
+}
+
+func (fn *FindNode) ParseOptions(options *[]string) error {
+	if len(*options) == 0 {
+		return errors.New("Recieved empty FIND_NODE RPC, Missing ID argument")
+	}
+	fn.id = &(*options)[0]
+	return nil
+}

--- a/internal/rpccommands/findnode/findnode_test.go
+++ b/internal/rpccommands/findnode/findnode_test.go
@@ -1,0 +1,39 @@
+package findnode_test
+
+import (
+	"kademlia/internal/address"
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/rpccommands/findnode"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	var findNode *findnode.FindNode
+	addr := address.New("address")
+	requestor := contact.NewContact(kademliaid.NewRandomKademliaID(), addr)
+
+	// should return a FindNode object
+	rpcId := kademliaid.NewRandomKademliaID()
+	findNode = findnode.New(&requestor, rpcId)
+	assert.IsType(t, &findnode.FindNode{}, findNode)
+}
+
+func TestParseOptions(t *testing.T) {
+	var findNode *findnode.FindNode
+	addr := address.New("address")
+	requestor := contact.NewContact(kademliaid.NewRandomKademliaID(), addr)
+
+	rpcId := kademliaid.NewRandomKademliaID()
+	findNode = findnode.New(&requestor, rpcId)
+
+	// should not report an error if the ID is specified
+	options := []string{"id"}
+	assert.NoError(t, findNode.ParseOptions(&options))
+
+	// should report an error if the ID is not specified
+	options = []string{}
+	assert.Error(t, findNode.ParseOptions(&options))
+}

--- a/internal/rpccommands/findnoderesp/findnoderesp.go
+++ b/internal/rpccommands/findnoderesp/findnoderesp.go
@@ -1,0 +1,39 @@
+package findenoderesp
+
+import (
+	"errors"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+type FindNodeResp struct {
+	rpcId *kademliaid.KademliaID
+	data  *string
+}
+
+func New(rpcId *kademliaid.KademliaID) *FindNodeResp {
+	return &FindNodeResp{rpcId: rpcId}
+}
+
+func (fnResp *FindNodeResp) Execute(node *node.Node) {
+	entry := node.NodeData.RPCPool.GetEntry(fnResp.rpcId)
+	if entry != nil {
+		log.Trace().Str("rpcID", fnResp.rpcId.String()).Msg("Writing to channel with rpcID")
+		entry.Channel <- *fnResp.data
+		log.Trace().Str("rpcID", fnResp.rpcId.String()).Msg("Done writing to channel")
+	} else {
+		log.Warn().Str("RPCId", fnResp.rpcId.String()).Msg("Received FIND_NODE_RESPONSE with unknown RPCId")
+	}
+}
+
+func (fnResp *FindNodeResp) ParseOptions(options *[]string) error {
+	if len(*options) == 0 {
+		return errors.New("Received empty FIND_NODE_RESPONSE RPC")
+	}
+	data := strings.Join(*options, " ")
+	fnResp.data = &data
+	return nil
+}

--- a/internal/rpccommands/findnoderesp/findnoderesp_test.go
+++ b/internal/rpccommands/findnoderesp/findnoderesp_test.go
@@ -1,0 +1,33 @@
+package findenoderesp_test
+
+import (
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/rpccommands/findnoderesp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	var fnResp *findenoderesp.FindNodeResp
+	rpcId := kademliaid.NewRandomKademliaID()
+
+	// should return a FindNode object
+	fnResp = findenoderesp.New(rpcId)
+	assert.IsType(t, &findenoderesp.FindNodeResp{}, fnResp)
+}
+
+func TestParseOptions(t *testing.T) {
+	var fnResp *findenoderesp.FindNodeResp
+
+	rpcId := kademliaid.NewRandomKademliaID()
+	fnResp = findenoderesp.New(rpcId)
+
+	// should report an error if the response contains no data
+	options := []string{}
+	assert.Error(t, fnResp.ParseOptions(&options))
+
+	// should not report an error if the response contains data
+	options = []string{"mydata"}
+	assert.NoError(t, fnResp.ParseOptions(&options))
+}

--- a/internal/shortlist/shortlist.go
+++ b/internal/shortlist/shortlist.go
@@ -1,0 +1,121 @@
+package shortlist
+
+import (
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"sort"
+
+	"github.com/rs/zerolog/log"
+)
+
+// TODO: Figure out a way to set this using env var. This is not as easy since
+// the value is used as the array size.
+const k = 5 // k-closest
+
+// Entry represents an entry in the shortlist used in the lookup algorithm.
+// an entry in the shortlist can be probed (if the RPC has been sent) and
+// active (if the probed contact has responded).
+type Entry struct {
+	Contact contact.Contact
+	Probed  bool
+	Active  bool
+}
+
+// The shortlist used in the lookup algorithm. The entries in the shortlist
+// are the k nodes which are closest to the key being searched for.
+type Shortlist struct {
+	Entries [k]*Entry
+	Closest *contact.Contact
+	target  *kademliaid.KademliaID
+}
+
+func (sl *Shortlist) Swap(i, j int) {
+	sl.Entries[i], sl.Entries[j] = sl.Entries[j], sl.Entries[i]
+}
+
+func (sl *Shortlist) Less(i, j int) bool {
+	if sl.Entries[j] == nil {
+		return true
+	}
+	if sl.Entries[i] == nil {
+		return false
+	}
+	return sl.Entries[i].Contact.Less(&sl.Entries[j].Contact)
+}
+
+// Len returns the number of non-null entries in the shortlist
+func (shortlist *Shortlist) Len() int {
+	length := 0
+	for _, entry := range shortlist.Entries {
+		if entry != nil {
+			length++
+		}
+	}
+	return length
+}
+
+// NewShortlist returns a shortlist of k entires given an initial list of
+// k (or less) candidates.
+//
+// NewShortlist assumes that the supplied candidates are sorted such that
+// the first candidate is the closest to the key
+func NewShortlist(target *kademliaid.KademliaID, candidates []contact.Contact) *Shortlist {
+	shortlist := &Shortlist{}
+	shortlist.Closest = &candidates[0]
+	shortlist.target = target
+	for i, contact := range candidates {
+		shortlist.Entries[i] = &Entry{contact, false, false}
+	}
+	return shortlist
+}
+
+func (sl *Shortlist) GetContacts() []contact.Contact {
+	contacts := []contact.Contact{}
+	for _, entry := range sl.Entries {
+		if entry != nil {
+			contacts = append(contacts, entry.Contact)
+		}
+	}
+	return contacts
+}
+
+// Add a contact to the shortlist
+//
+// The contact is only added if it does not already exist in the list and, if
+// the list already contains K contacts, only if it's distance to the id is
+// less than that of the furthest away node in the current shortlist.
+//
+// Assumes the shortlist to be sorted.
+func (sl *Shortlist) Add(c *contact.Contact) {
+	// Check if contact already exists
+	for _, entry := range sl.Entries {
+		if entry != nil {
+			if entry.Contact.ID.Equals(c.ID) {
+				log.Trace().
+					Str("ContactID", c.ID.String()).
+					Msg("Contact was not added as it already existed in the shortlist")
+				return
+			}
+		}
+	}
+
+	// calc distance of new candidate
+	c.CalcDistance(sl.target)
+
+	if sl.Len() == k {
+		if c.Less(&sl.Entries[k-1].Contact) {
+			sl.Entries[k-1] = &Entry{Contact: *c, Active: false, Probed: false}
+			sort.Sort(sl)
+			sl.Closest = &sl.Entries[0].Contact
+		}
+	} else {
+		for i := 0; i < len(sl.Entries); i++ {
+			if sl.Entries[i] == nil {
+				sl.Entries[i] = &Entry{Contact: *c, Active: false, Probed: false}
+				sort.Sort(sl)
+				sl.Closest = &sl.Entries[0].Contact
+				break
+			}
+		}
+	}
+}

--- a/internal/shortlist/shortlist_test.go
+++ b/internal/shortlist/shortlist_test.go
@@ -1,0 +1,107 @@
+package shortlist_test
+
+import (
+	"kademlia/internal/address"
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/shortlist"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: USE ENV CONST
+const k = 5
+
+func TestNewShortlist(t *testing.T) {
+
+	addr := address.New("address")
+	target := kademliaid.NewRandomKademliaID()
+	candidates := [k]contact.Contact{
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+	}
+	sl := shortlist.NewShortlist(target, candidates[:])
+
+	// should have k entries
+	assert.Len(t, sl.Entries, k)
+
+	// should not be marked as probed
+	for i := 0; i < k; i++ {
+		assert.False(t, sl.Entries[i].Probed)
+	}
+
+	// should not be marked as active
+	for i := 0; i < k; i++ {
+		assert.False(t, sl.Entries[i].Active)
+	}
+}
+
+func TestLen(t *testing.T) {
+	addr := address.New("address")
+	candidates := []contact.Contact{
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+		contact.NewContact(kademliaid.NewRandomKademliaID(), addr),
+	}
+	target := kademliaid.NewRandomKademliaID()
+	sl := shortlist.NewShortlist(target, candidates[:])
+
+	assert.Equal(t, 3, sl.Len())
+}
+
+func TestAdd(t *testing.T) {
+	adr := address.New("localhost")
+	targetID := kademliaid.NewRandomKademliaID()
+	var sl *shortlist.Shortlist
+
+	// Should not add a contact if already exists
+	c := contact.NewContact(kademliaid.NewRandomKademliaID(), adr)
+	c.CalcDistance(targetID)
+	sl = shortlist.NewShortlist(targetID, []contact.Contact{c})
+	sl.Add(&c)
+	assert.Equal(t, 1, sl.Len())
+
+	// Should add a contact if it doesn't exist
+	c2 := contact.NewContact(kademliaid.NewRandomKademliaID(), adr)
+	c2.CalcDistance(targetID)
+	sl = shortlist.NewShortlist(targetID, []contact.Contact{c2})
+	sl.Add(&c)
+	assert.Equal(t, 2, sl.Len())
+
+	// Should add and sort if list is not full
+	contacts := []contact.Contact{}
+	target := kademliaid.FromString(strings.Repeat("0", 40))
+	for i := 0; i < 4; i++ {
+		s := strconv.Itoa(i+1) + strings.Repeat("0", 39) // +1 to avoid all zeroes (equal to target)
+		contact := contact.NewContact(kademliaid.FromString(s), adr)
+		contact.CalcDistance(target)
+		contacts = append(contacts, contact)
+	}
+	sl = shortlist.NewShortlist(target, contacts)
+	c = contact.NewContact(kademliaid.FromString(strings.Repeat("0", 39)+"1"), adr)
+	c.CalcDistance(target)
+	sl.Add(&c)
+	assert.Equal(t, c, sl.Entries[0].Contact)
+
+	// Should add and sort if list is full
+	contacts = []contact.Contact{}
+	target = kademliaid.FromString(strings.Repeat("0", 40))
+	for i := 0; i < 5; i++ {
+		s := strconv.Itoa(i+1) + strings.Repeat("0", 39) // +1 to avoid all zeroes (equal to target)
+		contact := contact.NewContact(kademliaid.FromString(s), adr)
+		contact.CalcDistance(target)
+		contacts = append(contacts, contact)
+	}
+	sl = shortlist.NewShortlist(target, contacts)
+
+	c = contact.NewContact(kademliaid.FromString(strings.Repeat("0", 39)+"1"), adr)
+	c.CalcDistance(target)
+	sl.Add(&c)
+	assert.Equal(t, c, sl.Entries[0].Contact)
+}


### PR DESCRIPTION
The lookup algorithm was implemented by following the description in the
kademlia specification. Note that the current version is still missing
some key features of the lookup algorithm since we are using alpha=1
which makes it non-parallel. This will be fixed once we have merged
Martins FIND_VALUE branch as well since we need to fix some underlying
issues to get the algortihm working with alpha>1. The logic behind what
happens if no improvement of the closest node has been made after one
iteration also has to be implemented later.

Added CLI commands:
- Join: For joining the network, only executes a node lookup on itself
to fill the nodes routing table with entries.

Added RPCs:
- findnode: Used by the node lookup algorithm to search on the specified
key (id) this is the FIND_NODE RPC.
- findnoderesp: The response of a findnode request. This response
contains k contacts in its content with format <ID>!<Address>

Closes #7 

NOTE:
Not closing lookup algorithm issue #8 until we have fixed all the missing features.