### PR TITLE
Add PrintUsage() return string and tests

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -11,5 +11,5 @@ type Command interface {
 	// the struct
 	ParseOptions(options []string) error
 
-	PrintUsage()
+	PrintUsage() string
 }

--- a/internal/command/parser/parser.go
+++ b/internal/command/parser/parser.go
@@ -56,7 +56,7 @@ func ParseCmd(s string) Command {
 	err := command.ParseOptions(fields[1:]) // Extract all options
 	if err != nil {
 		log.Error().Str("error", err.Error()).Msg("Failed to parse options")
-		command.PrintUsage()
+		log.Info().Msg(command.PrintUsage())
 		return nil
 	}
 

--- a/internal/commands/addcontact/addcontact.go
+++ b/internal/commands/addcontact/addcontact.go
@@ -33,6 +33,6 @@ func (a *AddContact) ParseOptions(options []string) error {
 	return nil
 }
 
-func (a *AddContact) PrintUsage() {
-	log.Info().Msg("Usage: addcontact {nodeID} {address}")
+func (a *AddContact) PrintUsage() string {
+	return "Usage: addcontact {nodeID} {address}"
 }

--- a/internal/commands/addcontact/addcontact_test.go
+++ b/internal/commands/addcontact/addcontact_test.go
@@ -50,3 +50,10 @@ func TestExecute(t *testing.T) {
 	assert.Equal(t, "Contact added: 127.0.0.1:1776", res)
 	assert.Nil(t, err)
 }
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var addcCmd *addcontact.AddContact
+	assert.Equal(t, addcCmd.PrintUsage(), "Usage: addcontact {nodeID} {address}")
+
+}

--- a/internal/commands/exit/exit.go
+++ b/internal/commands/exit/exit.go
@@ -21,6 +21,6 @@ func (e *Exit) ParseOptions(options []string) error {
 	return nil
 }
 
-func (e *Exit) PrintUsage() {
-	log.Info().Msg("Usage: exit ")
+func (e *Exit) PrintUsage() string {
+	return "Usage: exit "
 }

--- a/internal/commands/exit/exit_test.go
+++ b/internal/commands/exit/exit_test.go
@@ -1,0 +1,29 @@
+package exit_test
+
+import (
+	"kademlia/internal/commands/exit"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOptions(t *testing.T) {
+	// should be nil
+	var exitCmd *exit.Exit
+	assert.Nil(t, exitCmd.ParseOptions([]string{}))
+	assert.Nil(t, exitCmd.ParseOptions([]string{"test"}))
+
+}
+
+func TestExecute(t *testing.T) {
+	// TODO: Test os.exit() for 100 % coverage
+
+}
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var exitCmd *exit.Exit
+	assert.Equal(t, exitCmd.PrintUsage(), "Usage: exit ")
+
+}

--- a/internal/commands/get/get.go
+++ b/internal/commands/get/get.go
@@ -38,6 +38,6 @@ func (get *Get) ParseOptions(options []string) error {
 	return nil
 }
 
-func (get *Get) PrintUsage() {
-	log.Info().Msg("USAGE: get <hash>")
+func (get *Get) PrintUsage() string {
+	return "USAGE: get <hash>"
 }

--- a/internal/commands/get/get_test.go
+++ b/internal/commands/get/get_test.go
@@ -23,3 +23,14 @@ func TestParseOption(t *testing.T) {
 	err = g.ParseOptions(options)
 	assert.Error(t, err)
 }
+
+func TestExecute(t *testing.T) {
+	// TODO: Not tested since .net lib
+}
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var getCmd *get.Get
+	assert.Equal(t, getCmd.PrintUsage(), "USAGE: get <hash>")
+
+}

--- a/internal/commands/getcontacts/getcontacts.go
+++ b/internal/commands/getcontacts/getcontacts.go
@@ -16,6 +16,6 @@ func (g *GetContacts) ParseOptions(options []string) error {
 	return nil
 }
 
-func (g *GetContacts) PrintUsage() {
-	log.Info().Msg("Usage: getcontacts")
+func (g *GetContacts) PrintUsage() string {
+	return "Usage: getcontacts"
 }

--- a/internal/commands/getcontacts/getcontacts_test.go
+++ b/internal/commands/getcontacts/getcontacts_test.go
@@ -26,3 +26,10 @@ func TestExecute(t *testing.T) {
 	assert.Equal(t, "Empty! Please, populate the routingtable...", res)
 	assert.Nil(t, err)
 }
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var getcsCmd *getcontacts.GetContacts
+	assert.Equal(t, getcsCmd.PrintUsage(), "Usage: getcontacts")
+
+}

--- a/internal/commands/getid/getid.go
+++ b/internal/commands/getid/getid.go
@@ -19,6 +19,6 @@ func (g *GetId) ParseOptions(options []string) error {
 	return nil
 }
 
-func (g *GetId) PrintUsage() {
-	log.Info().Msg("Usage: getid")
+func (g *GetId) PrintUsage() string {
+	return "Usage: getid"
 }

--- a/internal/commands/getid/getid_test.go
+++ b/internal/commands/getid/getid_test.go
@@ -31,3 +31,10 @@ func TestExecute(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, id.String(), res)
 }
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var getidCmd *getid.GetId
+	assert.Equal(t, getidCmd.PrintUsage(), "Usage: getid")
+
+}

--- a/internal/commands/initnode/initnode.go
+++ b/internal/commands/initnode/initnode.go
@@ -35,6 +35,6 @@ func (i *InitNode) ParseOptions(options []string) error {
 	return nil
 }
 
-func (i *InitNode) PrintUsage() {
-	log.Info().Msg("Usage: init {address}")
+func (i *InitNode) PrintUsage() string {
+	return "Usage: init {address}"
 }

--- a/internal/commands/initnode/initnode_test.go
+++ b/internal/commands/initnode/initnode_test.go
@@ -40,3 +40,10 @@ func TestExecute(t *testing.T) {
 	assert.Equal(t, "Node initialized", res)
 	assert.Nil(t, err)
 }
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var initCmd *initnode.InitNode
+	assert.Equal(t, initCmd.PrintUsage(), "Usage: init {address}")
+
+}

--- a/internal/commands/join/join.go
+++ b/internal/commands/join/join.go
@@ -19,6 +19,6 @@ func (j *Join) ParseOptions(options []string) error {
 	return nil
 }
 
-func (j *Join) PrintUsage() {
-	log.Info().Msg("Usage: join")
+func (j *Join) PrintUsage() string {
+	return "Usage: join"
 }

--- a/internal/commands/join/join_test.go
+++ b/internal/commands/join/join_test.go
@@ -1,0 +1,25 @@
+package join_test
+
+import (
+	"kademlia/internal/commands/join"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecute(t *testing.T) {
+	// TODO: Not tested since .net
+}
+
+func TestParseOptions(t *testing.T) {
+	var joinCmd *join.Join
+	assert.Nil(t, joinCmd.ParseOptions([]string{}))
+	assert.Nil(t, joinCmd.ParseOptions([]string{"test", "test"}))
+}
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var joinCmd *join.Join
+	assert.Equal(t, joinCmd.PrintUsage(), "Usage: join")
+
+}

--- a/internal/commands/message/message.go
+++ b/internal/commands/message/message.go
@@ -39,6 +39,6 @@ func (msg *Message) ParseOptions(options []string) error {
 	return nil
 }
 
-func (msg *Message) PrintUsage() {
-	log.Info().Msg("Usage: msg {target address} {message content}")
+func (msg *Message) PrintUsage() string {
+	return "Usage: msg {target address} {message content}"
 }

--- a/internal/commands/message/message_test.go
+++ b/internal/commands/message/message_test.go
@@ -42,3 +42,10 @@ func TestParseOptions(t *testing.T) {
 	err = msgCmd.ParseOptions([]string{"address"})
 	assert.NotNil(t, err)
 }
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var msgCmd *message.Message
+	assert.Equal(t, msgCmd.PrintUsage(), "Usage: msg {target address} {message content}")
+
+}

--- a/internal/commands/ping/ping.go
+++ b/internal/commands/ping/ping.go
@@ -30,6 +30,6 @@ func (p *Ping) ParseOptions(options []string) error {
 	return nil
 }
 
-func (p *Ping) PrintUsage() {
-	log.Info().Msg("Usage: ping {target address}")
+func (p *Ping) PrintUsage() string {
+	return "Usage: ping {target address}"
 }

--- a/internal/commands/ping/ping_test.go
+++ b/internal/commands/ping/ping_test.go
@@ -36,3 +36,10 @@ func TestParseOptions(t *testing.T) {
 	err = pingCmd.ParseOptions([]string{})
 	assert.NotNil(t, err)
 }
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var pingCmd *ping.Ping
+	assert.Equal(t, pingCmd.PrintUsage(), "Usage: ping {target address}")
+
+}

--- a/internal/commands/put/put.go
+++ b/internal/commands/put/put.go
@@ -38,6 +38,6 @@ func (put *Put) ParseOptions(options []string) error {
 	return nil
 }
 
-func (put *Put) PrintUsage() {
-	log.Info().Msg("put <file content>")
+func (put *Put) PrintUsage() string {
+	return "put <file content>"
 }

--- a/internal/commands/put/put_test.go
+++ b/internal/commands/put/put_test.go
@@ -21,3 +21,10 @@ func TestParseOptions(t *testing.T) {
 	assert.NotNil(t, err)
 
 }
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+	var putCmd *put.Put
+	assert.Equal(t, putCmd.PrintUsage(), "put <file content>")
+
+}

--- a/internal/commands/storage/storage.go
+++ b/internal/commands/storage/storage.go
@@ -20,6 +20,6 @@ func (p *Storage) ParseOptions(options []string) error {
 	return nil
 }
 
-func (p *Storage) PrintUsage() {
-	log.Info().Msg("Usage: data")
+func (p *Storage) PrintUsage() string {
+	return "Usage: data"
 }


### PR DESCRIPTION
PrintUsage() in every cli command returns a string which is logged in the parser if usage is wrong

Closes #41 

P.S. added some tests :1st_place_medal: 