### PR TITLE
Implement the bucket refresh procedure of network joining

### DIFF
--- a/cmd/kademliactl/kademliactl.go
+++ b/cmd/kademliactl/kademliactl.go
@@ -15,7 +15,7 @@ func reader(wg *sync.WaitGroup, r io.Reader) {
 	defer wg.Done()
 
 	//TODO: Don't hardcode buffer size to 1024 bytes
-	buf := make([]byte, 2058)
+	buf := make([]byte, 10000)
 	n, err := r.Read(buf[:])
 	if err != nil {
 		return

--- a/cmd/kademliactl/kademliactl.go
+++ b/cmd/kademliactl/kademliactl.go
@@ -15,7 +15,7 @@ func reader(wg *sync.WaitGroup, r io.Reader) {
 	defer wg.Done()
 
 	//TODO: Don't hardcode buffer size to 1024 bytes
-	buf := make([]byte, 1024)
+	buf := make([]byte, 2058)
 	n, err := r.Read(buf[:])
 	if err != nil {
 		return

--- a/internal/commands/getcontacts/getcontacts_test.go
+++ b/internal/commands/getcontacts/getcontacts_test.go
@@ -20,10 +20,11 @@ func TestParseOptions(t *testing.T) {
 func TestExecute(t *testing.T) {
 	var getcsCmd *getcontacts.GetContacts
 
-	// should return message informing that the routingtable is empty
+	// should indicate that the node is not initialized if the routing table
+	// does not exist
 	node := node.Node{}
 	res, err := getcsCmd.Execute(&node)
-	assert.Equal(t, "Empty! Please, populate the routingtable...", res)
+	assert.Equal(t, "The node is not initilized, it does not contain a routing table or any contacts", res)
 	assert.Nil(t, err)
 }
 

--- a/internal/kademliaid/kademliaid_test.go
+++ b/internal/kademliaid/kademliaid_test.go
@@ -5,6 +5,7 @@ import (
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/routingtable"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,11 +22,19 @@ func TestCalcDistance(t *testing.T) {
 }
 
 func TestLess(t *testing.T) {
-
-	// should return false
-	id := kademliaid.NewRandomKademliaID()
-	id2 := id
+	// should return false if the id is not closer
+	id := kademliaid.FromString(strings.Repeat("F", 40))
+	id2 := kademliaid.FromString(strings.Repeat("F", 39) + "0")
 	assert.False(t, id.Less(id2))
+
+	// should return true if the id is closer
+	id = kademliaid.FromString(strings.Repeat("F", 39) + "0")
+	id2 = kademliaid.FromString(strings.Repeat("F", 40))
+	assert.True(t, id.Less(id2))
+
+	// should return even if the two ids are the same
+	id2 = kademliaid.FromString(strings.Repeat("F", 39) + "0")
+	assert.False(t, id2.Less(id2))
 
 }
 

--- a/internal/kademliaid/kademliaid_test.go
+++ b/internal/kademliaid/kademliaid_test.go
@@ -1,11 +1,13 @@
 package kademliaid_test
 
 import (
+	"kademlia/internal/address"
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/routingtable"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"kademlia/internal/kademliaid"
 )
 
 func TestCalcDistance(t *testing.T) {
@@ -69,4 +71,19 @@ func TestNewRandomKademliaID(t *testing.T) {
 	id := kademliaid.NewRandomKademliaID()
 	assert.False(t, id.Equals(kademliaid.NewRandomKademliaID()))
 
+}
+
+func TestNewKademliaIDInRangeOfBucket(t *testing.T) {
+	id := kademliaid.NewRandomKademliaID()
+	addr := address.New("address")
+	rt := routingtable.NewRoutingTable(contact.NewContact(id, addr))
+	// should return a valid id for all the 160 buckets
+	// keep in mind that the routing tables GetBucketIndex will say that an id
+	// which differs on all bits is in bucket with index 0 so the order of the
+	// buckets is reversed from the description in the paper
+	for i := 0; i < kademliaid.IDLength*8; i++ {
+		newIdInRange := kademliaid.NewKademliaIDInRange(id, i)
+		bucket := rt.GetBucketIndex(newIdInRange)
+		assert.True(t, bucket == i)
+	}
 }

--- a/internal/routingtable/routingtable.go
+++ b/internal/routingtable/routingtable.go
@@ -84,21 +84,33 @@ func (routingTable *RoutingTable) FindClosestContacts(target *kademliaid.Kademli
 	return candidates.GetContacts(count)
 }
 
-// GetContacts returns a newline string with contacts in the nodes routingtable
+// GetContacts returns a string with contacts in the nodes routingtable, the
+// contacts are printed with the bucket they reside in. The bucket number
+// have been converted so that bucket 0 is the bucket with contacts of inside
+// the range 2^0 to 2^1 from the node
 func (routingTable *RoutingTable) GetContacts() string {
-	s := ""
 	if routingTable == nil {
-		return "Empty! Please, populate the routingtable..."
+		return "The node is not initilized, it does not contain a routing table or any contacts"
 	}
-	for _, bucket := range routingTable.buckets {
+	s := "\nContacts:\n"
+	numContacts := 0
+	for i, bucket := range routingTable.buckets {
 		if bucket != nil && bucket.Len() > 0 {
-			s += fmt.Sprintf("%+v\n", bucket.GetContactAndCalcDistance(routingTable.me.ID))
-
+			convertedBucketIndex := 160 - i
+			s += fmt.Sprintf(
+				"\nBucket %d:\n",
+				convertedBucketIndex,
+			)
+			contacts := bucket.GetContactAndCalcDistance(routingTable.me.ID)
+			numContacts += len(contacts)
+			for _, c := range contacts {
+				s += fmt.Sprintf("%s\n", c.String())
+			}
 		}
+
 	}
-
+	s += fmt.Sprintf("\nEnd of contacts.\nTotal number of contacts: %d", numContacts)
 	return s
-
 }
 
 // getBucketIndex get the correct Bucket index for the KademliaID

--- a/internal/routingtable/routingtable_test.go
+++ b/internal/routingtable/routingtable_test.go
@@ -19,7 +19,6 @@ func TestNewRoutingTable(t *testing.T) {
 	c := contact.NewContact(id, adr)
 	rt := routingtable.NewRoutingTable(c)
 	assert.NotNil(t, rt)
-	assert.Equal(t, "", rt.GetContacts())
 }
 
 func TestAddContact(t *testing.T) {
@@ -31,7 +30,7 @@ func TestAddContact(t *testing.T) {
 
 	// should be empty string
 	rt.AddContact(c)
-	assert.Equal(t, "", rt.GetContacts())
+	assert.Equal(t, "\nContacts:\n\nEnd of contacts.\nTotal number of contacts: 0", rt.GetContacts())
 
 	// should not be empty string
 	id = kademliaid.NewRandomKademliaID()
@@ -57,8 +56,8 @@ func TestFindClosestContacts(t *testing.T) {
 
 func TestGetContacts(t *testing.T) {
 	node := node.Node{}
-	// should return message informing that the routingtable is empty
-	assert.Equal(t, "Empty! Please, populate the routingtable...", node.RoutingTable.GetContacts())
+	// should return message informing that the routingtable does not exist
+	assert.Equal(t, "The node is not initilized, it does not contain a routing table or any contacts", node.RoutingTable.GetContacts())
 
 	// should return a contact in newline string format
 	id := kademliaid.NewRandomKademliaID()


### PR DESCRIPTION
## Refreshing buckets in network joining
The node now refreshes every bucket further away than the bucket its
closest neighbour resides in. This step is done after the initial node
lookup has been completed. The closest neighbour node is the first
contact in the list of contacts returned from the node lookup.

A bucket refresh is done by generating a new random ID within the
range of the bucket (for bucket i this is 2^i <= Distance(node, contact) < 2^(i+1))
and then performing a node lookup on that ID. This is repeated for all
buckets. This function can also be reused when implementing the bucket
refresh which is supposed to happen after no lookups have been made after
x time.

## GetIdInRange(nodeID, bucketIndex)
Implemented funcationality for generating a new NodeID which will be in
the range of a nodes bucket *i*. The implementation might be
hard to understand but what I basically do is loop through each byte in
the byte array of the nodes id (kademliaID is represented as a byte
array). And for each byte I copy the bits. This
continues until we reach bit BucketIndex+1 where we make sure that the
bit differs (otherwise the new ID would not be placed in the specified
bucket) then we generate random bits for the remaining bits of the new
ID.

Remember that a Contact will be placed in bucket i if the distance from
the node to the contact is within the range 2^i <= Distance(node,
contact) < 2^i+1.

It is also a bit mind fuck because the already implemented function in routing table which returns the bucketIndex of a given NodeID returns the index 0 if the ID differs on all bits e.g. bucket 160 if you follow the papers explanation.

## Misc
This PR also fixes an issue I noticed while testing this where we
don't create enough channels for the final round of FIND_* RPCs if the
closest contact did not change during the iteration. Fixed it by
creating k channels instead of alpha.

I also improved the getcontacts printout. It now prints in what bucket each contact is.
Had to increase the size of the buffer we read to in kademliactl since the contact list can become pretty large
when you have a larger amount of nodes.

Fixed an incorrect test.

Closes #92 