### PR TITLE
Don't log if log level is set in kademliactl

### DIFF
--- a/cmd/kademlia/kademlia.go
+++ b/cmd/kademlia/kademlia.go
@@ -29,7 +29,13 @@ func getHostIP() string {
 }
 
 func main() {
-	logger.InitLogger(os.Getenv("LOG_LEVEL"))
+	logLevel := os.Getenv("LOG_LEVEL")
+	if err := logger.InitLogger(logLevel); err == nil {
+		log.Info().Str("Level", logLevel).Msg("Log level set")
+	} else {
+		log.Error().Str("Level", logLevel).Msg("Failed to parse log level, defaulting to info level...")
+	}
+
 	host, err := os.Hostname()
 	ip := getHostIP()
 	if err != nil {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -8,14 +8,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func InitLogger(level string) {
+func InitLogger(level string) error {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
 	zerolog.SetGlobalLevel(zerolog.InfoLevel) //Default to info level
 	logLevel, err := zerolog.ParseLevel(level)
 	if err == nil {
 		zerolog.SetGlobalLevel(logLevel)
-		log.Info().Str("Level", level).Msg("Log level set")
-	} else {
-		log.Error().Str("Level", level).Msg("Failed to parse log level, defaulting to info level...")
 	}
+	return err
 }


### PR DESCRIPTION
Kademliactl should no longer log that a log level has been set every time a command is run.