### PR TITLE
Implement timed bucket refreshes

### DIFF
--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -12,7 +12,6 @@ type Bucket struct {
 	list *list.List
 }
 
-//TODO: Set through env
 const bucketSize = 20
 
 // NewBucket returns a new instance of a Bucket
@@ -61,7 +60,6 @@ func (bucket *Bucket) GetContactAndCalcDistance(target *KademliaID) []Contact {
 // has already been calculated. This array will never contain a contact with
 // the same nodeID as the requestorID.
 func (bucket *Bucket) GetContactAndCalcDistanceNoRequestor(target *KademliaID, requestorID *KademliaID) []Contact {
-
 	var contacts []Contact
 
 	for elt := bucket.list.Front(); elt != nil; elt = elt.Next() {

--- a/internal/bucket/bucket_test.go
+++ b/internal/bucket/bucket_test.go
@@ -1,0 +1,85 @@
+package bucket_test
+
+import (
+	"kademlia/internal/address"
+	"kademlia/internal/bucket"
+	"kademlia/internal/contact"
+	"kademlia/internal/kademliaid"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBucket(t *testing.T) {
+	// should create a bucket
+	b := bucket.NewBucket()
+	assert.NotNil(t, b)
+	assert.Equal(t, b.Len(), 0)
+}
+
+func TestAddContact(t *testing.T) {
+	// shoud be the same contact
+	id := kademliaid.NewRandomKademliaID()
+	adr := address.New("127.0.0.1")
+	c := contact.NewContact(id, adr)
+	b := bucket.NewBucket()
+	b.AddContact(c)
+	contact := b.GetContactAndCalcDistance(id)[0]
+	assert.Equal(t, contact.ID, c.ID)
+	assert.Equal(t, contact.Address, c.Address)
+}
+
+func TestGetContactAndCalcDistance(t *testing.T) {
+
+	// should be the same id
+	id1 := kademliaid.FromString("1111111111111111111100000000000000000000")
+	id2 := kademliaid.FromString("0000000000000000000011111111111111111111")
+	adr := address.New("127.0.0.1")
+	c1 := contact.NewContact(id1, adr)
+	c2 := contact.NewContact(id2, adr)
+	b := bucket.NewBucket()
+	b.AddContact(c1)
+	b.AddContact(c2)
+	c2 = b.GetContactAndCalcDistance(id1)[0]
+	c1 = b.GetContactAndCalcDistance(id1)[1]
+	assert.Equal(t, c1.ID, kademliaid.FromString("1111111111111111111100000000000000000000"))
+	assert.Equal(t, c2.ID, kademliaid.FromString("0000000000000000000011111111111111111111"))
+
+	// should have the correct distance
+	assert.Equal(t, c1.GetDistance(), kademliaid.FromString("0000000000000000000000000000000000000000"))
+	assert.Equal(t, c2.GetDistance(), kademliaid.FromString("1111111111111111111111111111111111111111"))
+}
+
+func TestGetContactAndCalcDistanceNoRequestor(t *testing.T) {
+
+	//should return the contacts
+	id1 := kademliaid.FromString("1111111111111111111100000000000000000000")
+	id2 := kademliaid.FromString("0000000000000000000011111111111111111111")
+	adr := address.New("127.0.0.1")
+	c1 := contact.NewContact(id1, adr)
+	b := bucket.NewBucket()
+	b.AddContact(c1)
+	carr := b.GetContactAndCalcDistanceNoRequestor(id1, id2)
+	assert.Equal(t, carr[0].ID, id1)
+	assert.Equal(t, b.Len(), 1)
+
+	// should not return the requestor
+	carr = b.GetContactAndCalcDistanceNoRequestor(id1, id1)
+	assert.Nil(t, carr)
+}
+
+func TestLen(t *testing.T) {
+	// should return 0
+	b := bucket.NewBucket()
+	assert.Equal(t, b.Len(), 0)
+
+	// shoud return a int 3
+	adr := address.New("127.0.0.1")
+	c1 := contact.NewContact(kademliaid.NewRandomKademliaID(), adr)
+	c2 := contact.NewContact(kademliaid.NewRandomKademliaID(), adr)
+	c3 := contact.NewContact(kademliaid.NewRandomKademliaID(), adr)
+	b.AddContact(c1)
+	b.AddContact(c2)
+	b.AddContact(c3)
+	assert.Equal(t, b.Len(), 3)
+}

--- a/internal/nodedata/nodedata.go
+++ b/internal/nodedata/nodedata.go
@@ -3,13 +3,15 @@ package nodedata
 import (
 	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/refreshtimer"
 	"kademlia/internal/routingtable"
 	"kademlia/internal/rpcpool"
 )
 
 type NodeData struct {
-	RoutingTable *routingtable.RoutingTable
-	DataStore    datastore.DataStore
-	ID           *kademliaid.KademliaID
-	RPCPool      *rpcpool.RPCPool
+	RoutingTable  *routingtable.RoutingTable
+	DataStore     datastore.DataStore
+	ID            *kademliaid.KademliaID
+	RPCPool       *rpcpool.RPCPool
+	RefreshTimers []*refreshtimer.RefreshTimer
 }

--- a/internal/refreshtimer/refreshtimer.go
+++ b/internal/refreshtimer/refreshtimer.go
@@ -1,0 +1,41 @@
+package refreshtimer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type RefreshTimer struct {
+	bucketIndex int
+	restart     chan bool
+}
+
+func NewRefreshTimer(bucketIndex int) *RefreshTimer {
+	rt := RefreshTimer{}
+	rt.bucketIndex = bucketIndex
+	rt.restart = make(chan bool)
+	return &rt
+}
+
+func (rt *RefreshTimer) StartRefreshTimer(doRefresh func(int)) {
+	go func() {
+		for {
+			//t := time.Duration(10) * time.Second // 10s
+			//t := time.Minute
+			t := time.Hour
+			select {
+			case <-rt.restart:
+				log.Trace().Str("Bucket", fmt.Sprint(rt.bucketIndex)).Msg("Restarted bucket refresh timer")
+			case <-time.After(t):
+				log.Trace().Str("Bucket", fmt.Sprint(rt.bucketIndex)).Msg("No lookup done in bucket range, refreshing it")
+				go doRefresh(rt.bucketIndex)
+			}
+		}
+	}()
+}
+
+func (rt *RefreshTimer) RestartRefreshTimer() {
+	rt.restart <- true // restart the refresh timer
+}

--- a/internal/refreshtimer/refreshtimer_test.go
+++ b/internal/refreshtimer/refreshtimer_test.go
@@ -1,0 +1,16 @@
+package refreshtimer_test
+
+import (
+	"kademlia/internal/refreshtimer"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRefreshTimer(t *testing.T) {
+	bucketIndex := 20
+	rt := refreshtimer.NewRefreshTimer(bucketIndex)
+
+	// should return a refresh timer
+	assert.IsType(t, refreshtimer.RefreshTimer{}, *rt)
+}

--- a/internal/routingtable/routingtable.go
+++ b/internal/routingtable/routingtable.go
@@ -2,11 +2,10 @@ package routingtable
 
 import (
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"kademlia/internal/bucket"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
-
-	"github.com/rs/zerolog/log"
 )
 
 const bucketSize = 20
@@ -125,4 +124,8 @@ func (routingTable *RoutingTable) GetBucketIndex(id *kademliaid.KademliaID) int 
 	}
 
 	return kademliaid.IDLength*8 - 1
+}
+
+func (routingTable *RoutingTable) GetBucket(index int) *bucket.Bucket {
+	return routingTable.buckets[index]
 }


### PR DESCRIPTION
The buckets in the nodes routing table will now periodically refresh if
no node lookup has been done in the ID range of the bucket within a
specfied time. Each time a lookup is done within the buckets range this
timer is restarted. If this is not the case the bucket will instead be
refreshed using the nodes RefreshBucket() method.

The node now has a property RefreshTimers which is a list of refresh
timers, one for each bucket (excluding the last bucket since this will
whp be empty). The refresh timers are started by giving them a callback
function which will be executed once the timer runs out. The refresh
timer then restarts once again.

I started working with what @bugmana  had on the branch but began having problems with cyclic dependencies so I moved it to a separate file and added the refresh timers to the NodeData. The problem is that when the timer runs out the nodes method RefreshBucket has to be called but this could be fixed if the node passed the entire function as an argument to each refresh timer.

Aron had added some tests for the bucket on the branch as well.

Closes #91 