### PR TITLE
81 ttl data

### DIFF
--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -2,31 +2,52 @@ package datastore
 
 import (
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"kademlia/internal/kademliaid"
+	"time"
 )
 
-type DataMap = map[kademliaid.KademliaID]string
+type DataMap = map[kademliaid.KademliaID]Data
 
 type DataStore struct {
-	data DataMap
+	store DataMap
+}
+
+type Data struct {
+	value   string
+	restart chan bool
 }
 
 func New() DataStore {
 	return DataStore{make(DataMap)}
 }
 
-// Insert a value into the store.
+// Insert a data into the store.
 // Uses SHA-1 hash of value as key.
+// Starts a TTL timer on the data
 func (d *DataStore) Insert(value string) {
 	id := kademliaid.NewKademliaID(&value)
-	d.data[id] = value
+	data := Data{}
+	data.value = value
+	data.restart = make(chan bool)
+	d.store[id] = data
+	d.StartRefreshTimer(data) // If successful insert, we start the TTL
+
 }
 
 // Gets the value from the store associated with the key.
 // Returns an empty string if the key is not found because go is an awful
 // language and should never have been invented.
 func (d *DataStore) Get(key kademliaid.KademliaID) string {
-	return d.data[key]
+	data := d.store[key]
+	d.RestartRefreshTimer(data) // Data is requested
+	return data.value
+}
+
+// Drop removes the data from the store
+func (d *DataStore) Drop(value string) {
+	id := kademliaid.NewKademliaID(&value)
+	delete(d.store, id)
 }
 
 // Pretty printing of store
@@ -41,14 +62,33 @@ func (d *DataStore) EntriesAsString() string {
 	map()
 	*/
 	var s string
-	if len(d.data) != 0 {
+	if len(d.store) != 0 {
 		s = "map("
-		for key, element := range d.data {
-			s = fmt.Sprintf("%s \n %x=%s", s, key, element)
+		for key, element := range d.store {
+			s = fmt.Sprintf("%s \n %x=%s", s, key, element) // TODO: map is now storing the data obj and not a string!
 		}
 		s += "\n)"
 	} else {
 		s = "map()"
 	}
 	return s
+}
+
+func (d *DataStore) StartRefreshTimer(data Data) {
+	go func() {
+		for {
+			t := time.Hour
+			select {
+			case <-data.restart:
+				log.Trace().Str("Data", data.value).Msg("Restarted data refresh timer")
+			case <-time.After(t):
+				log.Trace().Str("Data", data.value).Msg("No refresh done on data, data is silently deleted...")
+				go d.Drop(data.value)
+			}
+		}
+	}()
+}
+
+func (d *DataStore) RestartRefreshTimer(data Data) {
+	data.restart <- true // restart the refresh timer
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -41,6 +41,14 @@ func (node *Node) Init(address *address.Address) {
 			RefreshTimers: refreshTimers,
 		},
 	}
+
+	// start new refresh timers for each bucket, skip last bucket since no node
+	// will be in it whp
+	for i := 0; i < kademliaid.IDLength*8-1; i++ {
+		rt := refreshtimer.NewRefreshTimer(i)
+		node.RefreshTimers = append(node.RefreshTimers, rt)
+		rt.StartRefreshTimer(node.RefreshBucket)
+	}
 }
 
 // JoinNetwork performs a node lookup on on the nodes own ID. It then refreshes
@@ -49,13 +57,6 @@ func (node *Node) Init(address *address.Address) {
 // TODO: Should maybe check that the node knows of another node in the network.
 // This is not a problem as long as the init script is used.
 func (node *Node) JoinNetwork() {
-	// start new refresh timers for each bucket, skip last bucket since no node
-	// will be in it whp
-	for i := 0; i < kademliaid.IDLength*8-1; i++ {
-		rt := refreshtimer.NewRefreshTimer(i)
-		node.RefreshTimers = append(node.RefreshTimers, rt)
-		rt.StartRefreshTimer(node.RefreshBucket)
-	}
 
 	// lookup on self
 	kClosest := node.LookupContact(node.RoutingTable.GetMe().ID)


### PR DESCRIPTION
TTL Node data
- When data is stored on a node a timer of 1 hour is started 
- When timer expires the data is deleted from the node store
- If the data is request on a node and retrieved from that node the timer is restarted, the data will still be dropped on the k-nodes if not explicitly requested on one of the k-nodes
- If data is put:ed (transmitted) the timer is overridden with a new timer of 1 hour

Closes #81 