### PR TITLE
Implement REST api

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ Any node can told to execute any command by running the following
 docker exec -ti <container-name/id> kademliactl <command>
 ```
 
+### REST API
+All nodes support the following REST API,
+
+##### Method: `GET`, endpoint: `/objects/{hash}/`:
+The {hash} portion of the HTTP path is to be substituted for the hash of the object. A successful call should result in the contents of the object being responded with.
+
+Example:
+```
+curl <container-ip>:8080/objects/<hash>
+```
+
+##### Method: `POST`, endpoint: `/objects`:
+Each message sent to the endpoint must contain a data object in its HTTP body. If the operation is successful, the node will reply with 201 CREATED containing both the contents of the uploaded object and a Location: /objects/{hash} header, where {hash} will be substituted for the hash of the uploaded object.
+
+Example:
+```
+curl -X POST <container-ip>:8080/objects -d "<content>"
+```
+
 ### Setting log level
 
 The containers source the log level from the `LOG_LEVEL` variable in the

--- a/cmd/kademlia/kademlia.go
+++ b/cmd/kademlia/kademlia.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"kademlia/internal/command/listener"
+	"kademlia/internal/http/listener"
 	"kademlia/internal/logger"
 	"kademlia/internal/node"
 	"kademlia/internal/udplistener"
@@ -52,5 +53,6 @@ func main() {
 	node := node.Node{}
 
 	go cmdlistener.Listen(&node)
+	go httplistener.Listen(&node)
 	udplistener.Listen(ip, lport, &node)
 }

--- a/internal/http/listener/listener.go
+++ b/internal/http/listener/listener.go
@@ -1,0 +1,76 @@
+package httplistener
+
+import (
+	"fmt"
+	"io/ioutil"
+	cmdparser "kademlia/internal/command/parser"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"path"
+
+	"github.com/rs/zerolog/log"
+
+	"net/http"
+)
+
+// Wrap the handler in a struct so that we can pass the node object to it.
+// This so stupid, but so is go.
+type RequestHandler struct {
+	Node *node.Node
+}
+
+func (handler *RequestHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
+	log.Trace().Msg("Received GET request")
+	hash := path.Base(r.URL.String())
+
+	// If hash is equal to object then no hash was passed in
+	if hash == "objects" {
+		log.Info().Msg("Received GET request missing hash")
+		w.Write([]byte("Missing hash"))
+		return
+	}
+
+	cmd := cmdparser.ParseCmd(fmt.Sprintf("get %s", hash))
+	value, err := cmd.Execute(handler.Node)
+	if err != nil {
+		log.Error().Msg("Failed to execute get command")
+	}
+	w.Write([]byte(value))
+}
+
+func (handler *RequestHandler) handlePost(w http.ResponseWriter, r *http.Request) {
+	log.Trace().Msg("Received POST request")
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Error().Msgf("Error reading request body %s", err.Error())
+		return
+	}
+
+	cmd := cmdparser.ParseCmd(fmt.Sprintf("put %s", string(data)))
+	value, err := cmd.Execute(handler.Node)
+	if err != nil {
+		log.Error().Str("Error", err.Error()).Msg("Failed to execute put command")
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	// Add location header and set status code to 201 (created)
+	sData := string(data)
+	hash := kademliaid.NewKademliaID(&sData)
+	w.Header().Add("Location", "/objects/"+hash.String())
+	w.WriteHeader(201)
+
+	w.Write([]byte(value))
+}
+
+func Listen(node *node.Node) error {
+	requesthandler := RequestHandler{Node: node}
+
+	// Register handlers
+	http.HandleFunc("/objects/", requesthandler.HandleGet)
+	http.HandleFunc("/objects", requesthandler.handlePost)
+
+	// ListenAndServe always returns non-nil error and blocks until it does
+	err := http.ListenAndServe(":8080", nil)
+	return err
+}

--- a/internal/http/listener/listener_test.go
+++ b/internal/http/listener/listener_test.go
@@ -1,0 +1,58 @@
+package httplistener_test
+
+import (
+	"kademlia/internal/datastore"
+	httplistener "kademlia/internal/http/listener"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type HttpWriterMock struct {
+	mock.Mock
+}
+
+func (m *HttpWriterMock) Write(data []byte) (int, error) {
+	args := m.Called(data)
+	return args.Int(0), nil
+}
+
+func (mock *HttpWriterMock) WriteHeader(statusCode int) {
+}
+
+func (mock *HttpWriterMock) Header() http.Header {
+	return nil
+}
+
+func TestHandleGet(t *testing.T) {
+	var writerMock *HttpWriterMock
+	var n node.Node
+	var handler httplistener.RequestHandler
+	var req *http.Request
+
+	//Should tell user about missing hash
+	writerMock = new(HttpWriterMock)
+	req, _ = http.NewRequest("GET", "/objects/", nil)
+
+	n = node.Node{}
+	handler = httplistener.RequestHandler{Node: &n}
+	writerMock.On("Write", []byte("Missing hash")).Return(0, nil)
+	handler.HandleGet(writerMock, req)
+	writerMock.AssertExpectations(t)
+
+	// Should return the value if found
+	n = node.Node{}
+	writerMock = new(HttpWriterMock)
+	writerMock.On("Write", mock.Anything).Return(0, nil)
+	n.DataStore = datastore.New()
+	msg := "this is a message"
+	hash := kademliaid.NewKademliaID(&msg)
+	req, _ = http.NewRequest("POST", "/objects/"+hash.String(), nil)
+	n.DataStore.Insert(msg)
+	handler = httplistener.RequestHandler{Node: &n}
+	handler.HandleGet(writerMock, req)
+	writerMock.AssertCalled(t, "Write", []byte(msg+", from local node"))
+}


### PR DESCRIPTION
Closes #86 
This implements to REST endpoints that can be used to interact with the nodes.

You can do a GET command by running the following:
```bash
curl <container-ip>:8080/objects/<hash>
```

You can do a POST (store) command by running the following:
```bash
curl -X POST <container-ip>:8080/objects -d "<content>"
```