### PR TITLE
Refactor

### DIFF
--- a/internal/commands/message/message.go
+++ b/internal/commands/message/message.go
@@ -5,7 +5,6 @@ import (
 	"kademlia/internal/address"
 	"kademlia/internal/node"
 	kademliaMessage "kademlia/internal/rpc"
-	"kademlia/internal/udpsender"
 
 	"github.com/rs/zerolog/log"
 )
@@ -19,14 +18,13 @@ func (msg Message) Execute(node *node.Node) (string, error) {
 	log.Trace().Str("Target", msg.Target).Msg("Executing message command")
 	adr := address.New(msg.Target)
 	message := kademliaMessage.New(node.ID, msg.Content, adr)
-	udpSender := udpsender.New(adr)
-	err := message.Send(udpSender)
+	err := message.Send(node.Network.UdpSender, message.Target)
 
 	if err != nil {
 		log.Error().Msgf("Failed to write message to UDP: %s", err.Error())
-		log.Info().Str("Address", msg.Target).Str("Content", msg.Content).Msg("Message sent to address")
+		return "", err
 	}
-
+	log.Info().Str("Address", msg.Target).Str("Content", msg.Content).Msg("Message sent to address")
 	return "Message sent!", nil
 }
 

--- a/internal/commands/message/message_test.go
+++ b/internal/commands/message/message_test.go
@@ -1,6 +1,7 @@
 package message_test
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/commands/message"
 	"kademlia/internal/node"
 	"testing"
@@ -9,12 +10,20 @@ import (
 )
 
 func TestExecute(t *testing.T) {
-	// should return a string and not an error
 	node := &node.Node{}
+	node.Init(address.New("127.0.0.1:1234"))
 	msg := message.Message{}
+
+	// should be able to send a message to a valid target
+	msg.ParseOptions([]string{"127.0.0.1:1337", "hejsan"})
 	resp, err := msg.Execute(node)
 	assert.Nil(t, err)
 	assert.Equal(t, "Message sent!", resp)
+
+	// should not be able to send a message to an invalid target
+	msg.ParseOptions([]string{"123", "hello"})
+	resp, err = msg.Execute(node)
+	assert.Error(t, err)
 }
 
 func TestParseOptions(t *testing.T) {

--- a/internal/commands/ping/ping.go
+++ b/internal/commands/ping/ping.go
@@ -3,7 +3,6 @@ package ping
 import (
 	"errors"
 	"kademlia/internal/address"
-	"kademlia/internal/network"
 	"kademlia/internal/node"
 
 	"github.com/rs/zerolog/log"
@@ -16,7 +15,7 @@ type Ping struct {
 func (p Ping) Execute(node *node.Node) (string, error) {
 	log.Trace().Str("Target", p.Target).Msg("Executing ping command")
 	adr := address.New(p.Target)
-	network.Net.SendPingMessage(node.ID, adr)
+	node.Network.SendPingMessage(node.ID, adr)
 
 	return "Ping sent!", nil
 

--- a/internal/commands/ping/ping_test.go
+++ b/internal/commands/ping/ping_test.go
@@ -1,6 +1,7 @@
 package ping_test
 
 import (
+	"kademlia/internal/address"
 	"kademlia/internal/commands/ping"
 	"kademlia/internal/node"
 	"testing"
@@ -10,7 +11,9 @@ import (
 
 func TestExecute(t *testing.T) {
 	// should return a string and not an error
+	addr := address.New("127.0.0.1:1234")
 	node := &node.Node{}
+	node.Init(addr)
 	ping := ping.Ping{}
 	resp, err := ping.Execute(node)
 	assert.Nil(t, err)

--- a/internal/commands/put/put.go
+++ b/internal/commands/put/put.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"github.com/rs/zerolog/log"
 	"kademlia/internal/kademliaid"
-	"kademlia/internal/network"
 	"kademlia/internal/node"
 	"strings"
 )
@@ -24,7 +23,7 @@ func (put *Put) Execute(node *node.Node) (string, error) {
 
 	// Send STORE RPCs
 	for _, closeNode := range closestNodes {
-		network.Net.SendStoreMessage(node.ID, closeNode.Address, []byte(put.fileContent))
+		node.Network.SendStoreMessage(node.ID, closeNode.Address, []byte(put.fileContent))
 	}
 
 	return key.String(), nil

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -11,17 +11,16 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var Net Network
-
-type Network struct{}
+type Network struct {
+	UdpSender *udpsender.UDPSender
+}
 
 // SendPongMessage replies a "PONG" message to the remote "pinger" address
 func (network *Network) SendPongMessage(senderId *kademliaid.KademliaID, target *address.Address, id *kademliaid.KademliaID) {
 	rpc := rpc.New(senderId, "PONG", target)
 	rpc.RPCId = id
-	udpSender := udpsender.New(target)
+	err := rpc.Send(network.UdpSender, target)
 
-	err := rpc.Send(udpSender)
 	if err != nil {
 		log.Error().Msgf("Failed to write RPC PING message to UDP: %s", err.Error())
 	}
@@ -31,9 +30,8 @@ func (network *Network) SendPongMessage(senderId *kademliaid.KademliaID, target 
 // SendPingMessage sends a "PING" message to a remote address
 func (network *Network) SendPingMessage(senderId *kademliaid.KademliaID, target *address.Address) {
 	rpc := rpc.New(senderId, "PING", target)
-	udpSender := udpsender.New(target)
 
-	err := rpc.Send(udpSender)
+	err := rpc.Send(network.UdpSender, target)
 	if err != nil {
 		log.Error().Msgf("Failed to write RPC PING message to UDP: %s", err.Error())
 	}
@@ -41,8 +39,7 @@ func (network *Network) SendPingMessage(senderId *kademliaid.KademliaID, target 
 }
 
 func (network *Network) SendFindContactMessage(rpc *rpc.RPC) {
-	udpSender := udpsender.New(rpc.Target)
-	err := rpc.Send(udpSender)
+	err := rpc.Send(network.UdpSender, rpc.Target)
 	if err != nil {
 		log.Error().Msgf("Failed to write FIND_NODE RPC to UDP: %s", err.Error())
 	}
@@ -55,8 +52,7 @@ func (network *Network) SendFindContactRespMessage(senderId *kademliaid.Kademlia
 
 	rpc := rpc.NewWithID(senderId, fmt.Sprintf("%s %s", "FIND_NODE_RESPONSE", *content), target, rpcId)
 
-	udpSender := udpsender.New(target)
-	err := rpc.Send(udpSender)
+	err := rpc.Send(network.UdpSender, target)
 	if err != nil {
 		log.Error().Msgf("Failed to write FIND_NODE_RESPONSE message to UDP: %s", err.Error())
 	}
@@ -64,8 +60,7 @@ func (network *Network) SendFindContactRespMessage(senderId *kademliaid.Kademlia
 }
 
 func (network *Network) SendFindDataMessage(rpc *rpc.RPC) {
-	udpSender := udpsender.New(rpc.Target)
-	err := rpc.Send(udpSender)
+	err := rpc.Send(network.UdpSender, rpc.Target)
 
 	if err != nil {
 		log.Error().Msgf("Failed to write RPC FIND_VALUE message to UDP: %s", err.Error())
@@ -75,8 +70,7 @@ func (network *Network) SendFindDataMessage(rpc *rpc.RPC) {
 
 func (network *Network) SendFindDataRespMessage(senderID *kademliaid.KademliaID, target *address.Address, rpcId *kademliaid.KademliaID, content *string) {
 	rpc := rpc.NewWithID(senderID, fmt.Sprintf("FIND_VALUE_RESP %s", *content), target, rpcId)
-	udpSender := udpsender.New(target)
-	err := rpc.Send(udpSender)
+	err := rpc.Send(network.UdpSender, target)
 
 	if err != nil {
 		log.Error().Msgf("Failed to write RPC FIND_VALUE_RESP message to UDP: %s", err.Error())
@@ -86,8 +80,7 @@ func (network *Network) SendFindDataRespMessage(senderID *kademliaid.KademliaID,
 
 func (network *Network) SendStoreMessage(senderId *kademliaid.KademliaID, target *address.Address, data []byte) {
 	rpc := rpc.New(senderId, fmt.Sprintf("%s %s", "STORE", data), target)
-	udpSender := udpsender.New(target)
-	err := rpc.Send(udpSender)
+	err := rpc.Send(network.UdpSender, target)
 
 	if err != nil {
 		log.Error().Msgf("Failed to write RPC STORE message to UDP: %s", err.Error())

--- a/internal/nodedata/nodedata.go
+++ b/internal/nodedata/nodedata.go
@@ -3,6 +3,7 @@ package nodedata
 import (
 	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/network"
 	"kademlia/internal/refreshtimer"
 	"kademlia/internal/routingtable"
 	"kademlia/internal/rpcpool"
@@ -14,4 +15,5 @@ type NodeData struct {
 	ID            *kademliaid.KademliaID
 	RPCPool       *rpcpool.RPCPool
 	RefreshTimers []*refreshtimer.RefreshTimer
+	Network       network.Network
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -17,7 +17,7 @@ type RPC struct {
 }
 
 type Sender interface {
-	Send(string) error
+	Send(data string, target *address.Address) error
 }
 
 func New(senderId *kademliaid.KademliaID, content string, target *address.Address) RPC {
@@ -38,8 +38,8 @@ func NewWithID(senderId *kademliaid.KademliaID, content string, target *address.
 }
 
 // Sends the message using the send function
-func (rpc *RPC) Send(sender Sender) error {
-	return sender.Send(rpc.serialize())
+func (rpc *RPC) Send(sender Sender, target *address.Address) error {
+	return sender.Send(rpc.serialize(), target)
 }
 
 func (rpc *RPC) serialize() string {

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -17,8 +17,8 @@ type SenderMock struct {
 	mock.Mock
 }
 
-func (m *SenderMock) Send(data string) error {
-	args := m.Called(data)
+func (m *SenderMock) Send(data string, target *address.Address) error {
+	args := m.Called(data, target)
 	return args.Error(0)
 }
 
@@ -74,15 +74,15 @@ func TestSend(t *testing.T) {
 
 	// Should return the error from send if there was an error
 	senderMock = new(SenderMock)
-	senderMock.On("Send", rpcSerialized).Return(errors.New("this is an error"))
-	err = rpc.Send(senderMock)
+	senderMock.On("Send", rpcSerialized, adr).Return(errors.New("this is an error"))
+	err = rpc.Send(senderMock, adr)
 	assert.Equal(t, err, errors.New("this is an error"))
 	senderMock.AssertExpectations(t)
 
 	// Should return nil if send does not return an error
 	senderMock = new(SenderMock)
-	senderMock.On("Send", rpcSerialized).Return(nil)
-	err = rpc.Send(senderMock)
+	senderMock.On("Send", rpcSerialized, adr).Return(nil)
+	err = rpc.Send(senderMock, adr)
 	assert.NoError(t, err)
 	senderMock.AssertExpectations(t)
 }

--- a/internal/rpccommands/findnode/findnode.go
+++ b/internal/rpccommands/findnode/findnode.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
-	"kademlia/internal/network"
 	"kademlia/internal/node"
 	"os"
 	"strconv"
@@ -33,7 +32,7 @@ func (fn *FindNode) Execute(node *node.Node) {
 	// Respond with k closest nodes to the key
 	kClosest := node.FindKClosest(kademliaid.FromString(*fn.id), fn.requestor.ID, k)
 	content := contact.SerializeContacts(kClosest)
-	network.Net.SendFindContactRespMessage(node.ID, fn.requestor.Address, fn.rpcId, &content)
+	node.Network.SendFindContactRespMessage(node.ID, fn.requestor.Address, fn.rpcId, &content)
 }
 
 func (fn *FindNode) ParseOptions(options *[]string) error {

--- a/internal/rpccommands/findvalue/findvalue.go
+++ b/internal/rpccommands/findvalue/findvalue.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
-	"kademlia/internal/network"
 	"kademlia/internal/node"
 	"os"
 	"strconv"
@@ -28,7 +27,7 @@ func (find *FindValue) Execute(node *node.Node) {
 	if value := node.DataStore.Get(*find.hash); value != "" {
 		log.Debug().Str("Value", value).Str("Hash", find.hash.String()).Msg("Found key")
 		s := "VALUE=" + value
-		network.Net.SendFindDataRespMessage(node.ID, find.requestor.Address, find.rpcId, &s)
+		node.Network.SendFindDataRespMessage(node.ID, find.requestor.Address, find.rpcId, &s)
 	} else {
 
 		k, err := strconv.Atoi(os.Getenv("K"))
@@ -38,7 +37,7 @@ func (find *FindValue) Execute(node *node.Node) {
 		log.Debug().Str("Hash", find.hash.String()).Msg("Did not find key")
 		closest := node.FindKClosest(find.hash, find.requestor.ID, k)
 		data := contact.SerializeContacts(closest)
-		network.Net.SendFindDataRespMessage(node.ID, find.requestor.Address, find.rpcId, &data)
+		node.Network.SendFindDataRespMessage(node.ID, find.requestor.Address, find.rpcId, &data)
 	}
 }
 

--- a/internal/rpccommands/ping/ping.go
+++ b/internal/rpccommands/ping/ping.go
@@ -3,7 +3,6 @@ package ping
 import (
 	"kademlia/internal/address"
 	"kademlia/internal/kademliaid"
-	"kademlia/internal/network"
 	"kademlia/internal/node"
 
 	"github.com/rs/zerolog/log"
@@ -19,9 +18,9 @@ func New(senderAddress *address.Address, rpcId *kademliaid.KademliaID) Ping {
 }
 
 func (ping Ping) Execute(node *node.Node) {
-	log.Trace().Msg("Executing FIND_NODE RPC")
+	log.Trace().Msg("Executing PING RPC")
 	// Respond with pong
-	network.Net.SendPongMessage(node.ID, ping.senderAddress, ping.rpcId)
+	node.Network.SendPongMessage(node.ID, ping.senderAddress, ping.rpcId)
 }
 
 func (ping Ping) ParseOptions(options *[]string) error {

--- a/internal/rpcpool/rpcpool.go
+++ b/internal/rpcpool/rpcpool.go
@@ -33,10 +33,8 @@ func (pool *RPCPool) Delete(rpcId *kademliaid.KademliaID) {
 	delete(pool.entries, *rpcId)
 }
 
-func (pool *RPCPool) Lock() {
+func (pool *RPCPool) WithLock(f func()) {
 	pool.lock.Lock()
-}
-
-func (pool *RPCPool) Unlock() {
+	f()
 	pool.lock.Unlock()
 }

--- a/internal/udpsender/udpsender.go
+++ b/internal/udpsender/udpsender.go
@@ -1,42 +1,39 @@
 package udpsender
 
 import (
-	"github.com/rs/zerolog/log"
 	"kademlia/internal/address"
 	"net"
 	"os"
+
+	"github.com/rs/zerolog/log"
 )
 
 // UDPSender holds the target UDP address and the sender address
 type UDPSender struct {
-	target *net.UDPAddr
-	sender *net.UDPAddr
+	conn *net.UDPConn
 }
 
-// New Creates a UDPSender from given target address and resolves the sender address
-func New(target *address.Address) UDPSender {
-
-	port, err := target.GetPortAsInt()
+func New() (*UDPSender, error) {
+	sport := ":" + os.Getenv("SEND_PORT") // Get the sender port from env
+	laddr, err := net.ResolveUDPAddr("udp4", sport)
+	conn, err := net.ListenUDP("udp4", laddr)
 	if err != nil {
-		log.Error().Str("Address", target.String()).Msgf("Failed to parse given string port to int: %s", err)
+		return nil, err
 	}
-
-	sport := ":" + os.Getenv("SEND_PORT")           // Get the sender port from env
-	laddr, err := net.ResolveUDPAddr("udp4", sport) // Set the sender address, since only port is given it only resolves the ip
-
-	return UDPSender{target: &net.UDPAddr{IP: net.ParseIP(target.GetHost()), Port: port}, sender: laddr}
+	return &UDPSender{conn: conn}, nil
 }
 
-// Send sends the udp packet to the udp target from given port
-func (udp UDPSender) Send(data string) error {
-
-	conn, err := net.DialUDP("udp4", udp.sender, udp.target)
-	defer conn.Close() // Close the connection to avoid error bind: address already in use
-
+func (udp *UDPSender) Send(data string, target *address.Address) error {
+	adr, err := net.ResolveUDPAddr("udp", target.String())
 	if err != nil {
-		log.Error().Msgf("Failed to dial to UDP address: %s", err)
+		return err
 	}
 
-	_, err = conn.Write([]byte(data))
+	var n int
+	n, err = udp.conn.WriteTo([]byte(data), adr)
+	log.Trace().Int("BytesSent", n).
+		Str("LAddr", udp.conn.LocalAddr().String()).
+		Str("RAddr", target.String()).
+		Msg("Send UDP packet")
 	return err
 }


### PR DESCRIPTION
Implements method WIthlock on rpc pool. This is simply a higher order function that takes a function f and locks
the rpc pool's lock before calling f, and then unlocks the lock after f
has finished executing. This means the lock doesn't manually have to be
locked/unlocked and thus eliminates the risk of forgetting to
lock/unlock.

Now the node has a single udpsender (rather than creating a new for each
request) that takes the target address as a parameter when sending
(rather than at the object's instantiation).
Also this sender uses the same port source port for each request.