### PR TITLE
Implement TTL delay

### DIFF
--- a/internal/commands/put/put.go
+++ b/internal/commands/put/put.go
@@ -2,10 +2,11 @@ package put
 
 import (
 	"errors"
-	"github.com/rs/zerolog/log"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/node"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 type Put struct {
@@ -19,7 +20,7 @@ func (put *Put) Execute(node *node.Node) (string, error) {
 	// closestNodes := node.FindKClosest(&key, nil, k)
 	closestNodes := node.LookupContact(&key)
 
-	node.Store(&put.fileContent)
+	node.Store(&put.fileContent, &closestNodes, node.RoutingTable.GetMe())
 
 	// Send STORE RPCs
 	for _, closeNode := range closestNodes {

--- a/internal/commands/storage/storage_test.go
+++ b/internal/commands/storage/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"kademlia/internal/address"
 	"kademlia/internal/commands/storage"
+	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/node"
 	"testing"
@@ -20,7 +21,8 @@ func TestExecute(t *testing.T) {
 	n.Init(address.New("127.0.0.1"))
 	storedVal := "this is a test"
 	storedKey := kademliaid.NewKademliaID(&storedVal)
-	n.DataStore.Insert(storedVal)
+	contacts := &[]contact.Contact{}
+	n.DataStore.Insert(storedVal, contacts, nil, nil)
 	expected := fmt.Sprintf("map( \n %x=%s\n)", storedKey, storedVal)
 
 	// should return the nodes stored key-value pairs

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"kademlia/internal/contact"
 	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
 )
@@ -17,7 +18,8 @@ func TestGet(t *testing.T) {
 	// Should be able to  get
 	d = datastore.New()
 	value := "hello"
-	d.Insert(value)
+	contacts := &[]contact.Contact{}
+	d.Insert(value, contacts, nil, nil)
 	assert.Equal(t, d.Get(kademliaid.NewKademliaID(&value)), "hello")
 
 	// Should not be able to get non-existent key
@@ -32,7 +34,8 @@ func TestInsert(t *testing.T) {
 	//should be able to insert
 	d = datastore.New()
 	value := "hello"
-	d.Insert(value)
+	contacts := &[]contact.Contact{}
+	d.Insert(value, contacts, nil, nil)
 	assert.Equal(t, d.Get(kademliaid.NewKademliaID(&value)), "hello")
 }
 
@@ -46,8 +49,9 @@ func TestEntriesAsString(t *testing.T) {
 	//should print key-value pairs when non-empty
 	d = datastore.New()
 	v1, v2 := "hello", "world"
-	d.Insert(v1)
-	d.Insert(v2)
+	contacts := &[]contact.Contact{}
+	d.Insert(v1, contacts, nil, nil)
+	d.Insert(v2, contacts, nil, nil)
 	whitespaces := regexp.MustCompile(`\s+`)
 	fmt.Println(whitespaces.ReplaceAllString(d.EntriesAsString(), ""))
 	assert.Contains(t, d.EntriesAsString(), fmt.Sprintf("%x=%s", kademliaid.NewKademliaID(&v1), v1))
@@ -59,8 +63,9 @@ func TestDrop(t *testing.T) {
 
 	d = datastore.New()
 	v1, v2 := "hello", "world"
-	d.Insert(v1)
-	d.Insert(v2)
+	contacts := &[]contact.Contact{}
+	d.Insert(v1, contacts, nil, nil)
+	d.Insert(v2, contacts, nil, nil)
 
 	// should delete the entry
 	d.Drop("hello")

--- a/internal/http/listener/listener_test.go
+++ b/internal/http/listener/listener_test.go
@@ -1,6 +1,7 @@
 package httplistener_test
 
 import (
+	"kademlia/internal/contact"
 	"kademlia/internal/datastore"
 	httplistener "kademlia/internal/http/listener"
 	"kademlia/internal/kademliaid"
@@ -51,7 +52,8 @@ func TestHandleGet(t *testing.T) {
 	msg := "this is a message"
 	hash := kademliaid.NewKademliaID(&msg)
 	req, _ = http.NewRequest("POST", "/objects/"+hash.String(), nil)
-	n.DataStore.Insert(msg)
+	contacts := &[]contact.Contact{}
+	n.DataStore.Insert(msg, contacts, nil, nil)
 	handler = httplistener.RequestHandler{Node: &n}
 	handler.HandleGet(writerMock, req)
 	writerMock.AssertCalled(t, "Write", []byte(msg+", from local node"))

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -351,9 +351,9 @@ func (node *Node) LookupData(hash *kademliaid.KademliaID) string {
 	return s
 }
 
-func (node *Node) Store(value *string) {
+func (node *Node) Store(value *string, contacts *[]contact.Contact, originator *contact.Contact) {
 	log.Trace().Str("Value", *value).Msg("Storing value")
-	node.DataStore.Insert(*value)
+	node.DataStore.Insert(*value, contacts, originator, node.Network.UdpSender)
 }
 
 // FindKClosest returns a list of candidates containing the k closest nodes

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -21,7 +21,8 @@ func TestStore(t *testing.T) {
 	// should be equal
 	value := "TEST"
 	id := kademliaid.NewKademliaID(&value)
-	n.Store(&value)
+	contacts := &[]contact.Contact{}
+	n.Store(&value, contacts, nil)
 	assert.Equal(t, n.NodeData.DataStore.Get(id), "TEST")
 }
 

--- a/internal/routingtable/routingtable.go
+++ b/internal/routingtable/routingtable.go
@@ -2,10 +2,11 @@ package routingtable
 
 import (
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"kademlia/internal/bucket"
 	"kademlia/internal/contact"
 	"kademlia/internal/kademliaid"
+
+	"github.com/rs/zerolog/log"
 )
 
 const bucketSize = 20

--- a/internal/rpc/parser/parser.go
+++ b/internal/rpc/parser/parser.go
@@ -7,11 +7,12 @@ import (
 	"kademlia/internal/rpc"
 	"kademlia/internal/rpccommand"
 	"kademlia/internal/rpccommands/findnode"
-	"kademlia/internal/rpccommands/findnoderesp"
+	findenoderesp "kademlia/internal/rpccommands/findnoderesp"
 	"kademlia/internal/rpccommands/findvalue"
 	"kademlia/internal/rpccommands/findvalueresp"
 	"kademlia/internal/rpccommands/ping"
 	"kademlia/internal/rpccommands/pong"
+	"kademlia/internal/rpccommands/refresh"
 	"kademlia/internal/rpccommands/store"
 	"strings"
 
@@ -35,6 +36,9 @@ func ParseRPC(requestor *contact.Contact, rpc *rpc.RPC) (rpccommand.RPCCommand, 
 	case "PONG":
 		rpcLog.Msg("PONG received")
 		cmd = pong.New()
+	case "REFRESH":
+		rpcLog.Msg("REFRESH received")
+		cmd = new(refresh.Refresh)
 	case "STORE":
 		rpcLog.Msg("STORE received")
 		cmd = new(store.Store)

--- a/internal/rpccommands/refresh/refresh.go
+++ b/internal/rpccommands/refresh/refresh.go
@@ -1,0 +1,31 @@
+package refresh
+
+import (
+	"errors"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+
+	"github.com/rs/zerolog/log"
+)
+
+type Refresh struct {
+	hash kademliaid.KademliaID
+}
+
+func (r *Refresh) Execute(node *node.Node) {
+	log.Trace().Msg("Executing REFRESH RPC")
+
+	// Calling Get restarts the timer
+	if value := node.DataStore.Get(r.hash); value == "" {
+		log.Warn().Str("Hash", r.hash.String()).Msg("Received refresh on non existent value")
+	}
+}
+
+func (r *Refresh) ParseOptions(options *[]string) error {
+	if len(*options) < 1 {
+		return errors.New("Missing hash")
+	}
+	hash := (*options)[0]
+	r.hash = *kademliaid.FromString(hash)
+	return nil
+}

--- a/internal/rpccommands/refresh/refresh_test.go
+++ b/internal/rpccommands/refresh/refresh_test.go
@@ -1,0 +1,20 @@
+package refresh_test
+
+import (
+	"testing"
+)
+
+func TestExecute(t *testing.T) {
+	// TODO: Hugo knows the way
+
+}
+
+func TestParseOption(t *testing.T) {
+	// TODO: Hugo knows the way
+
+}
+
+func TestPrintUsage(t *testing.T) {
+	// should be equal
+
+}

--- a/internal/rpccommands/store/store.go
+++ b/internal/rpccommands/store/store.go
@@ -14,7 +14,7 @@ type Store struct {
 
 func (store *Store) Execute(node *node.Node) {
 	log.Trace().Msg("Executing FIND_NODE RPC")
-	node.Store(&store.fileContent)
+	node.Store(&store.fileContent, nil, nil)
 }
 
 func (store *Store) ParseOptions(options *[]string) error {

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -1,4 +1,4 @@
-CONT_NAME="^kademlia_kademlia." # Common part of container names
+CONT_NAME="kademlia_kademlia." # Common part of container names
 
 echo "Initilizing all running Kademlia containers..."
 


### PR DESCRIPTION
Closes #82 

Please, make sure to test this carefully.

Now, when inserting into the datastore you have to pass a contact
pointer. If this pointer is non-nil then the node that is inserting is the node
where the insert was initiated, and if it is nil then it is not. This
means that this pointer will be non-nil when a node receives STORE
rpc-command and nil when a node receives the put cli-command.

Introduces a new rpc called REFRESH, which contains the hash of the file
to refresh and is used to tell another node to restart its refresh timer.
Also, each datastore entry takes a list of contacts that indicate at
which other contacts the value was stored when initially inserted. This
is used to remember which nodes to send REFRESH rpcs to.