### PR TITLE
Implement forget cli-command

### DIFF
--- a/internal/command/parser/parser.go
+++ b/internal/command/parser/parser.go
@@ -6,6 +6,7 @@ import (
 	. "kademlia/internal/command"
 	"kademlia/internal/commands/addcontact"
 	"kademlia/internal/commands/exit"
+	"kademlia/internal/commands/forget"
 	"kademlia/internal/commands/get"
 	"kademlia/internal/commands/getcontacts"
 	"kademlia/internal/commands/getid"
@@ -48,6 +49,8 @@ func ParseCmd(s string) Command {
 		command = new(put.Put)
 	case "join":
 		command = new(join.Join)
+	case "forget":
+		command = new(forget.Forget)
 	default:
 		log.Error().Str("command", cmd).Msg("Received unknown command")
 		return nil

--- a/internal/commands/forget/forget.go
+++ b/internal/commands/forget/forget.go
@@ -1,0 +1,34 @@
+package forget
+
+import (
+	"errors"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+
+	"github.com/rs/zerolog/log"
+)
+
+type Forget struct {
+	hash kademliaid.KademliaID
+}
+
+func (forget *Forget) Execute(node *node.Node) (string, error) {
+	log.Trace().Msg("Executing forget command")
+
+	log.Trace().Str("ID", forget.hash.String()).Msg("Forgetting data entry")
+	err := node.DataStore.Forget(&forget.hash)
+
+	return "", err
+}
+
+func (forget *Forget) ParseOptions(options []string) error {
+	if len(options) < 1 {
+		return errors.New("Missing hash")
+	}
+	forget.hash = *kademliaid.FromString(options[0])
+	return nil
+}
+
+func (forget *Forget) PrintUsage() string {
+	return "USAGE: forget <hash>"
+}

--- a/internal/commands/forget/forget_test.go
+++ b/internal/commands/forget/forget_test.go
@@ -1,0 +1,61 @@
+package forget_test
+
+import (
+	"kademlia/internal/commands/forget"
+	"kademlia/internal/contact"
+	"kademlia/internal/datastore"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"kademlia/internal/nodedata"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecute(t *testing.T) {
+	var err error
+	var n node.Node
+	value := "hello world"
+	hash := kademliaid.NewKademliaID(&value)
+	var f forget.Forget
+	contacts := &[]contact.Contact{}
+
+	// Should not return an error if the value exists
+	f = forget.Forget{}
+	n = node.Node{NodeData: nodedata.NodeData{DataStore: datastore.New()}}
+	n.DataStore.Insert(value, contacts, nil, nil)
+	err = f.ParseOptions([]string{hash.String()})
+	assert.Nil(t, err)
+	_, err = f.Execute(&n)
+	assert.NoError(t, err)
+
+	// Should return an error if the value does not exists
+	f = forget.Forget{}
+	n = node.Node{NodeData: nodedata.NodeData{DataStore: datastore.New()}}
+	err = f.ParseOptions([]string{hash.String()})
+	assert.Nil(t, err)
+	_, err = f.Execute(&n)
+	assert.Error(t, err)
+}
+
+func TestParseOptions(t *testing.T) {
+	var err error
+	value := "hello world"
+	hash := kademliaid.NewKademliaID(&value)
+	var f forget.Forget
+
+	// Should return an error if the hash was not specified
+	f = forget.Forget{}
+	err = f.ParseOptions([]string{})
+	assert.EqualError(t, err, "Missing hash")
+
+	// Should not return an error if the hash was specified
+	f = forget.Forget{}
+	err = f.ParseOptions([]string{hash.String()})
+	assert.NoError(t, err)
+}
+
+func TestPrintUsage(t *testing.T) {
+	f := forget.Forget{}
+	assert.Equal(t, "USAGE: forget <hash>", f.PrintUsage())
+}


### PR DESCRIPTION
Closes #83 

Each entry in the datastore now has a bool that indicates whether or not
the value has been marked as forgotten. If a value has been marked as
forgotten, then it will be deleted and no REFRESH rpcs will be sent to
the other node during the next refresh timer interval and the timer will
be stopped.

The kademlia spec doesn't really mention whether or not the value should be deleted at the initiator node (the one that receives the forget command) as far as i could see, but i think it makes the most sense, so implemented it that  way.