### PR TITLE
Added multiple missing tests

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -27,6 +27,8 @@ services:
       - ALPHA=3
       - LISTEN_PORT=1776
       - SEND_PORT=1777
+      - REFRESH_TIME=5
+      - TTL_TIME=10
 
 networks:
   kademlia_dev_network:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -29,6 +29,7 @@ services:
       - SEND_PORT=1777
       - REFRESH_TIME=5
       - TTL_TIME=10
+      - BUCKET_REFRESH_TIME=3600
 
 networks:
   kademlia_dev_network:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,17 +1,17 @@
 version: "3"
 services:
   kademlia:
-    image: kadlab_prod 
+    image: kadlab_prod
     build:
       context: .
       dockerfile: prod.Dockerfile
     deploy:
       mode: replicated
-      replicas: 50  
-#        resources:
-#           limits:
-#              cpus: "0.1"
-#              memory: 50M
+      replicas: 50
+      #        resources:
+      #           limits:
+      #              cpus: "0.1"
+      #              memory: 50M
       restart_policy:
         condition: on-failure
         delay: 5s
@@ -25,6 +25,7 @@ services:
       - ALPHA=3
       - LISTEN_PORT=1776
       - SEND_PORT=1777
-      
+      - BUCKET_REFRESH_TIME=3600
+
 networks:
   kademlia_network:

--- a/internal/command/parser/parser_test.go
+++ b/internal/command/parser/parser_test.go
@@ -63,6 +63,10 @@ func TestParseCmd(t *testing.T) {
 	cmd = cmdparser.ParseCmd("join")
 	assert.NotNil(t, cmd)
 
+	// should be able to parse a forget command
+	cmd = cmdparser.ParseCmd("forget hash")
+	assert.NotNil(t, cmd)
+
 	//should return nil if an invalid command was passed
 	cmd = cmdparser.ParseCmd("non-existent command")
 	assert.Nil(t, cmd)

--- a/internal/commands/exit/exit.go
+++ b/internal/commands/exit/exit.go
@@ -10,10 +10,13 @@ import (
 type Exit struct {
 }
 
+// this is just so we can test execute
+var ExitFunction = os.Exit
+
 func (e Exit) Execute(node *node.Node) (string, error) {
 	log.Trace().Msg("Executing exit command")
 	log.Info().Msg("Node exiting...")
-	os.Exit(0)
+	ExitFunction(0)
 	return "Node exited", nil
 }
 

--- a/internal/commands/exit/exit_test.go
+++ b/internal/commands/exit/exit_test.go
@@ -2,10 +2,14 @@ package exit_test
 
 import (
 	"kademlia/internal/commands/exit"
+	"kademlia/internal/datastore"
+	"kademlia/internal/node"
+	"kademlia/internal/nodedata"
 
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestParseOptions(t *testing.T) {
@@ -16,9 +20,22 @@ func TestParseOptions(t *testing.T) {
 
 }
 
-func TestExecute(t *testing.T) {
-	// TODO: Test os.exit() for 100 % coverage
+type ExitMock struct {
+	mock.Mock
+}
 
+func (m *ExitMock) exit(n int) {
+	m.Called(0)
+}
+
+func TestExecute(t *testing.T) {
+	exitMock := ExitMock{}
+	exitMock.On("exit", 0)
+	exit.ExitFunction = exitMock.exit
+	e := exit.Exit{}
+	n := node.Node{NodeData: nodedata.NodeData{DataStore: datastore.New()}}
+	e.Execute(&n)
+	exitMock.AssertExpectations(t)
 }
 
 func TestPrintUsage(t *testing.T) {

--- a/internal/commands/get/get_test.go
+++ b/internal/commands/get/get_test.go
@@ -2,6 +2,11 @@ package get_test
 
 import (
 	"kademlia/internal/commands/get"
+	"kademlia/internal/contact"
+	"kademlia/internal/datastore"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"kademlia/internal/nodedata"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +31,19 @@ func TestParseOption(t *testing.T) {
 
 func TestExecute(t *testing.T) {
 	// TODO: Not tested since .net lib
+
+	// should return the value if it existed locally
+	contacts := &[]contact.Contact{}
+	value := "hello world"
+	hash := kademliaid.NewKademliaID(&value)
+	n := node.Node{NodeData: nodedata.NodeData{DataStore: datastore.New()}}
+	n.DataStore.Insert(value, contacts, nil, nil)
+
+	cmd := get.Get{}
+	cmd.ParseOptions([]string{hash.String()})
+	res, err := cmd.Execute(&n)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world, from local node", res)
 }
 
 func TestPrintUsage(t *testing.T) {

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -25,6 +25,24 @@ func (m *SenderMock) Send(data string, target *address.Address) error {
 	return args.Error(0)
 }
 
+func TestForget(t *testing.T) {
+	d := datastore.New()
+	value := "hello"
+	key := kademliaid.NewKademliaID(&value)
+	contacts := &[]contact.Contact{}
+	d.Insert(value, contacts, nil, nil)
+
+	// should mark the data as forgotten
+	err := d.Forget(&key)
+	assert.Nil(t, err)
+
+	// should return an error when trying to forget a non-existing value
+	value = "byebye"
+	key = kademliaid.NewKademliaID(&value)
+	err = d.Forget(&key)
+	assert.NotNil(t, err)
+}
+
 func TestGet(t *testing.T) {
 	var d datastore.DataStore
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -222,7 +222,7 @@ func (node *Node) LookupDataHandleResponses(sl *shortlist.Shortlist,
 	return result
 }
 
-func getEnvIntVariable(variable string, defaultValue int) int {
+func GetEnvIntVariable(variable string, defaultValue int) int {
 	val, err := strconv.Atoi(os.Getenv(variable))
 	if err != nil {
 		log.Error().Msgf("Failed to convert env variable %s from string to int: %s", variable, err)
@@ -290,8 +290,8 @@ func NewRPCWithID(senderId *kademliaid.KademliaID, content string, target *addre
 }
 
 func setupLookUpAlgorithm(node *Node, id *kademliaid.KademliaID) (alpha int, k int, sl *shortlist.Shortlist, channels []chan string) {
-	alpha = getEnvIntVariable("ALPHA", 3)
-	k = getEnvIntVariable("K", 5)
+	alpha = GetEnvIntVariable("ALPHA", 3)
+	k = GetEnvIntVariable("K", 5)
 	sl = shortlist.NewShortlist(id, node.FindKClosest(id, nil, alpha))
 
 	// might need more than alpha channels on final probe is closest did not change

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -236,7 +236,7 @@ func GetEnvIntVariable(variable string, defaultValue int) int {
 //
 // TODO: Ignore request after waiting X time
 func (node *Node) LookupContact(id *kademliaid.KademliaID) []contact.Contact {
-	alpha, k, sl, channels := setupLookUpAlgorithm(node, id)
+	alpha, k, sl, channels := SetupLookUpAlgorithm(node, id)
 
 	// Restart refresh timer of the bucket this ID is in range of
 	if *id != *node.ID {
@@ -289,7 +289,7 @@ func NewRPCWithID(senderId *kademliaid.KademliaID, content string, target *addre
 	}
 }
 
-func setupLookUpAlgorithm(node *Node, id *kademliaid.KademliaID) (alpha int, k int, sl *shortlist.Shortlist, channels []chan string) {
+func SetupLookUpAlgorithm(node *Node, id *kademliaid.KademliaID) (alpha int, k int, sl *shortlist.Shortlist, channels []chan string) {
 	alpha = GetEnvIntVariable("ALPHA", 3)
 	k = GetEnvIntVariable("K", 5)
 	sl = shortlist.NewShortlist(id, node.FindKClosest(id, nil, alpha))
@@ -300,7 +300,7 @@ func setupLookUpAlgorithm(node *Node, id *kademliaid.KademliaID) (alpha int, k i
 }
 
 func (node *Node) LookupData(hash *kademliaid.KademliaID) string {
-	alpha, k, sl, channels := setupLookUpAlgorithm(node, hash)
+	alpha, k, sl, channels := SetupLookUpAlgorithm(node, hash)
 
 	// Restart the refresh timer of the bucket this ID is in range of
 	bucketIndex := node.RoutingTable.GetBucketIndex(hash)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -119,7 +119,7 @@ func (node *Node) ProbeAlpha(
 	return numProbed, rpcIds
 }
 
-func deserializeContacts(data string, targetId *kademliaid.KademliaID) []*contact.Contact {
+func DeserializeContacts(data string, targetId *kademliaid.KademliaID) []*contact.Contact {
 	contacts := []*contact.Contact{}
 	for _, sContact := range strings.Split(data, " ") {
 		if sContact != "" {
@@ -151,7 +151,7 @@ func (node *Node) lookupContactHandleResponses(
 			data := <-(*channels)[i]
 			// parse contacts from response data
 			contactsMutex.Lock()
-			contacts = append(contacts, deserializeContacts(data, targetId)...)
+			contacts = append(contacts, DeserializeContacts(data, targetId)...)
 			contactsMutex.Unlock()
 		}(i, &wg, &contactsMutex)
 	}
@@ -202,7 +202,7 @@ func (node *Node) lookupDataHandleResponses(sl *shortlist.Shortlist,
 				sl.Entries[i].ReturnedValue = true
 			} else {
 				contactsMutex.Lock()
-				contacts = append(contacts, deserializeContacts(data, targetId)...)
+				contacts = append(contacts, DeserializeContacts(data, targetId)...)
 				contactsMutex.Unlock()
 			}
 		}(i, &wg, &contactsMutex)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -90,7 +90,7 @@ func (node *Node) RefreshBucket(bucketIndex int) {
 }
 
 // Probes at most alpha nodes from the shortlist with content
-func (node *Node) probeAlpha(
+func (node *Node) ProbeAlpha(
 	sl *shortlist.Shortlist,
 	channels *[]chan string,
 	content string,
@@ -250,7 +250,7 @@ func (node *Node) LookupContact(id *kademliaid.KademliaID) []contact.Contact {
 	for {
 		closestSoFar := sl.Closest
 
-		numProbed, rpcIds := node.probeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_NODE", id), alpha)
+		numProbed, rpcIds := node.ProbeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_NODE", id), alpha)
 
 		// If no new nodes were probed this iteration the search is done
 		if numProbed == 0 {
@@ -264,7 +264,7 @@ func (node *Node) LookupContact(id *kademliaid.KademliaID) []contact.Contact {
 		// the search since no node closer to the target was found this iteration
 		if sl.Closest == closestSoFar {
 			log.Trace().Msg("Closest node not updated")
-			numProbed, rpcIds := node.probeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_NODE", id), k)
+			numProbed, rpcIds := node.ProbeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_NODE", id), k)
 
 			node.lookupContactHandleResponses(sl, id, numProbed, &channels, rpcIds)
 			break
@@ -316,7 +316,7 @@ func (node *Node) LookupData(hash *kademliaid.KademliaID) string {
 	for {
 		closestSoFar := sl.Closest
 
-		numProbed, rpcIDs := node.probeAlpha(sl, &channels, fmt.Sprintf("FIND_VALUE %s", hash.String()), alpha)
+		numProbed, rpcIDs := node.ProbeAlpha(sl, &channels, fmt.Sprintf("FIND_VALUE %s", hash.String()), alpha)
 
 		if numProbed == 0 {
 			log.Trace().Msg("FIND_VALUE lookup became stale")
@@ -330,7 +330,7 @@ func (node *Node) LookupData(hash *kademliaid.KademliaID) string {
 
 		if sl.Closest == closestSoFar {
 			log.Trace().Msg("Closest node not updated")
-			numProbed, rpcIds := node.probeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_VALUE", hash), k)
+			numProbed, rpcIds := node.ProbeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_VALUE", hash), k)
 
 			result = node.lookupDataHandleResponses(sl, hash, numProbed, &channels, rpcIds)
 			if result != "" {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -134,7 +134,7 @@ func DeserializeContacts(data string, targetId *kademliaid.KademliaID) []*contac
 }
 
 // Handles the responses from the probed nodes during a node lookup
-func (node *Node) lookupContactHandleResponses(
+func (node *Node) LookupContactHandleResponses(
 	sl *shortlist.Shortlist,
 	targetId *kademliaid.KademliaID,
 	numProbed int,
@@ -168,7 +168,7 @@ func (node *Node) lookupContactHandleResponses(
 	}
 }
 
-func (node *Node) lookupDataHandleResponses(sl *shortlist.Shortlist,
+func (node *Node) LookupDataHandleResponses(sl *shortlist.Shortlist,
 	targetId *kademliaid.KademliaID,
 	numProbed int,
 	channels *[]chan string,
@@ -243,7 +243,7 @@ func (node *Node) LookupContact(id *kademliaid.KademliaID) []contact.Contact {
 	}
 
 	sl := shortlist.NewShortlist(id, node.FindKClosest(id, nil, alpha))
-	// might need more than alpha channels on final probe is closest did not change
+	// might need more than alpha channels on final probe if closest did not change
 	channels := make([]chan string, k)
 
 	// iterative lookup until the search becomes stale
@@ -258,7 +258,7 @@ func (node *Node) LookupContact(id *kademliaid.KademliaID) []contact.Contact {
 			break
 		}
 
-		node.lookupContactHandleResponses(sl, id, numProbed, &channels, rpcIds)
+		node.LookupContactHandleResponses(sl, id, numProbed, &channels, rpcIds)
 
 		// Send FIND_NODE to all unqueried nodes in the shortlist and terminate
 		// the search since no node closer to the target was found this iteration
@@ -266,7 +266,7 @@ func (node *Node) LookupContact(id *kademliaid.KademliaID) []contact.Contact {
 			log.Trace().Msg("Closest node not updated")
 			numProbed, rpcIds := node.ProbeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_NODE", id), k)
 
-			node.lookupContactHandleResponses(sl, id, numProbed, &channels, rpcIds)
+			node.LookupContactHandleResponses(sl, id, numProbed, &channels, rpcIds)
 			break
 		}
 	}
@@ -323,7 +323,7 @@ func (node *Node) LookupData(hash *kademliaid.KademliaID) string {
 			break
 		}
 
-		result = node.lookupDataHandleResponses(sl, hash, numProbed, &channels, rpcIDs)
+		result = node.LookupDataHandleResponses(sl, hash, numProbed, &channels, rpcIDs)
 		if result != "" {
 			return result
 		}
@@ -332,7 +332,7 @@ func (node *Node) LookupData(hash *kademliaid.KademliaID) string {
 			log.Trace().Msg("Closest node not updated")
 			numProbed, rpcIds := node.ProbeAlpha(sl, &channels, fmt.Sprintf("%s %s", "FIND_VALUE", hash), k)
 
-			result = node.lookupDataHandleResponses(sl, hash, numProbed, &channels, rpcIds)
+			result = node.LookupDataHandleResponses(sl, hash, numProbed, &channels, rpcIds)
 			if result != "" {
 				return result
 			}

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -8,6 +8,7 @@ import (
 	"kademlia/internal/kademliaid"
 	"kademlia/internal/rpc"
 	"kademlia/internal/shortlist"
+	"os"
 	"sync"
 
 	"kademlia/internal/node"
@@ -266,4 +267,9 @@ func TestFindKClosest(t *testing.T) {
 	kClosest := n.FindKClosest(key, id1, 3)
 	// contact c1 should not be returned since is has the same id as the requestor
 	assert.Equal(t, 2, len(kClosest))
+}
+
+func TestGetEnvIntVariable(t *testing.T) {
+	os.Setenv("TEST_VAR", "1337")
+	assert.Equal(t, 1337, node.GetEnvIntVariable("TEST_VAR", 123))
 }

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"fmt"
 	"kademlia/internal/address"
 	"kademlia/internal/contact"
 	"kademlia/internal/datastore"
@@ -13,6 +14,26 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDeserializeContacts(t *testing.T) {
+	addr := address.New("127.0.0.1:1234")
+	targetId := kademliaid.NewRandomKademliaID()
+	id1 := kademliaid.NewRandomKademliaID()
+	id2 := kademliaid.NewRandomKademliaID()
+	data := fmt.Sprintf("%s!%s %s!%s", id1.String(), addr.String(), id2.String(), addr.String())
+
+	// should deserialize the contacts when data contains correctly formatted
+	// contacts
+	res := node.DeserializeContacts(data, targetId)
+	assert.Equal(t, 2, len(res))
+	assert.Equal(t, *id1, *res[0].ID)
+	assert.Equal(t, *id2, *res[1].ID)
+
+	// should return an empty array of contacts if the data is empty
+	res = node.DeserializeContacts("", targetId)
+	assert.NotNil(t, res)
+	assert.Equal(t, 0, len(res))
+}
 
 func TestProbeAlpha(t *testing.T) {
 	addr := address.New("127.0.0.1:1234")

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -270,6 +270,25 @@ func TestFindKClosest(t *testing.T) {
 }
 
 func TestGetEnvIntVariable(t *testing.T) {
+	// should return the value of the env var if it is set
 	os.Setenv("TEST_VAR", "1337")
 	assert.Equal(t, 1337, node.GetEnvIntVariable("TEST_VAR", 123))
+
+	// should return the default value if the env var is not set
+	assert.Equal(t, 123, node.GetEnvIntVariable("TEST_VAR2", 123))
+}
+
+func TestSetupLookupAlgorithm(t *testing.T) {
+	n := node.Node{}
+	addr := address.New("127.0.0.1:1234")
+	n.Init(addr)
+	c := contact.NewContact(kademliaid.NewRandomKademliaID(), addr)
+	n.RoutingTable.AddContact(c)
+
+	// should return the vars needed in the lookup algo
+	alpha, k, sl, channels := node.SetupLookUpAlgorithm(&n, n.ID)
+	assert.Equal(t, 3, alpha)
+	assert.Equal(t, 5, k)
+	assert.Equal(t, 1, sl.Len())
+	assert.Equal(t, k, len(channels))
 }

--- a/internal/refreshtimer/refreshtimer.go
+++ b/internal/refreshtimer/refreshtimer.go
@@ -2,6 +2,8 @@ package refreshtimer
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -21,10 +23,16 @@ func NewRefreshTimer(bucketIndex int) *RefreshTimer {
 
 func (rt *RefreshTimer) StartRefreshTimer(doRefresh func(int)) {
 	go func() {
+		// get the refresh time (in seconds) from env or default to 1 hour
+		bucketRefreshTime, err := strconv.Atoi(os.Getenv("BUCKET_REFRESH_TIME"))
+		if err != nil {
+			log.Error().Msgf("Failed to convert env variable REFRESH_TIME from string to int: %s", err)
+			bucketRefreshTime = 3600
+		}
 		for {
 			//t := time.Duration(10) * time.Second // 10s
 			//t := time.Minute
-			t := time.Hour
+			t := time.Duration(bucketRefreshTime) * time.Second
 			select {
 			case <-rt.restart:
 				log.Trace().Str("Bucket", fmt.Sprint(rt.bucketIndex)).Msg("Restarted bucket refresh timer")

--- a/internal/refreshtimer/refreshtimer_test.go
+++ b/internal/refreshtimer/refreshtimer_test.go
@@ -2,10 +2,22 @@ package refreshtimer_test
 
 import (
 	"kademlia/internal/refreshtimer"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+type DoerMock struct {
+	mock.Mock
+}
+
+func (m *DoerMock) Do(bucketIndex int) {
+	m.Called(bucketIndex)
+	return
+}
 
 func TestNewRefreshTimer(t *testing.T) {
 	bucketIndex := 20
@@ -13,4 +25,39 @@ func TestNewRefreshTimer(t *testing.T) {
 
 	// should return a refresh timer
 	assert.IsType(t, refreshtimer.RefreshTimer{}, *rt)
+}
+
+func TestStartRefreshTimer(t *testing.T) {
+	var rt *refreshtimer.RefreshTimer
+
+	// should not fail if the refresh time env var is not set
+	rt = refreshtimer.NewRefreshTimer(10)
+	rt.StartRefreshTimer(func(int) { return })
+	time.Sleep(time.Second)
+
+	// should refresh the bucket (by calling the do function) if the timer is
+	// not restarted
+	doerMock := new(DoerMock)
+	rt = refreshtimer.NewRefreshTimer(20)
+	os.Setenv("BUCKET_REFRESH_TIME", "1")
+	doerMock.On("Do", 20).Return()
+	rt.StartRefreshTimer(func(b int) { doerMock.Do(b) })
+	// sleep to trigger refresh
+	time.Sleep(time.Second * 2)
+	doerMock.AssertExpectations(t)
+	doerMock.AssertNumberOfCalls(t, "Do", 1)
+
+	// should be able to restart the refresh timer
+	doerMock2 := new(DoerMock)
+	rt = refreshtimer.NewRefreshTimer(30)
+	doerMock2.On("Do", 30).Return()
+	os.Setenv("BUCKET_REFRESH_TIME", "1")
+	rt.StartRefreshTimer(func(b int) { doerMock2.Do(b) })
+	time.Sleep(time.Duration(time.Millisecond) * 500)
+	rt.RestartRefreshTimer()
+	time.Sleep(time.Duration(time.Millisecond) * 700)
+	doerMock2.AssertNotCalled(t, "Do")
+	time.Sleep(time.Duration(time.Millisecond) * 500)
+	doerMock2.AssertExpectations(t)
+	doerMock2.AssertNumberOfCalls(t, "Do", 1)
 }

--- a/internal/rpc/parser/parser_test.go
+++ b/internal/rpc/parser/parser_test.go
@@ -13,6 +13,7 @@ import (
 	"kademlia/internal/rpccommands/findvalueresp"
 	"kademlia/internal/rpccommands/ping"
 	"kademlia/internal/rpccommands/pong"
+	"kademlia/internal/rpccommands/refresh"
 	"kademlia/internal/rpccommands/store"
 	"testing"
 
@@ -68,6 +69,12 @@ func TestParseRPC(t *testing.T) {
 	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
 	assert.Nil(t, err)
 	assert.IsType(t, &findvalueresp.FindValueResp{}, rpcCmd)
+
+	// Should be able to parse a REFRESH RPC
+	r = rpc.New(senderId, "REFRESH", adr)
+	rpcCmd, err = rpcparser.ParseRPC(&c, &r)
+	assert.Nil(t, err)
+	assert.IsType(t, &refresh.Refresh{}, rpcCmd)
 
 	//Should not parse an unknown RPC
 	r = rpc.New(senderId, "HELLO", adr)

--- a/internal/rpccommands/findnoderesp/findnoderesp_test.go
+++ b/internal/rpccommands/findnoderesp/findnoderesp_test.go
@@ -1,8 +1,12 @@
 package findenoderesp_test
 
 import (
+	"kademlia/internal/datastore"
 	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"kademlia/internal/nodedata"
 	"kademlia/internal/rpccommands/findnoderesp"
+	"kademlia/internal/rpcpool"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +19,25 @@ func TestNew(t *testing.T) {
 	// should return a FindNode object
 	fnResp = findenoderesp.New(rpcId)
 	assert.IsType(t, &findenoderesp.FindNodeResp{}, fnResp)
+}
+
+func TestExecute(t *testing.T) {
+	n := node.Node{NodeData: nodedata.NodeData{DataStore: datastore.New(), RPCPool: rpcpool.New()}}
+	rpcID := kademliaid.NewRandomKademliaID()
+	n.RPCPool.Add(rpcID)
+	findRespCmd := findenoderesp.New(rpcID)
+	var content, data string
+	var channel chan string
+
+	// Should return just the content of the rpc if the value was not found
+	content = "some content"
+	findRespCmd.ParseOptions(&[]string{content})
+	go func() {
+		findRespCmd.Execute(&n)
+	}()
+	channel = n.RPCPool.GetEntry(rpcID).Channel
+	data = <-channel
+	assert.Equal(t, content, data)
 }
 
 func TestParseOptions(t *testing.T) {

--- a/internal/rpccommands/refresh/refresh_test.go
+++ b/internal/rpccommands/refresh/refresh_test.go
@@ -1,20 +1,38 @@
 package refresh_test
 
 import (
+	"kademlia/internal/address"
+	"kademlia/internal/kademliaid"
+	"kademlia/internal/node"
+	"kademlia/internal/rpccommands/refresh"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExecute(t *testing.T) {
-	// TODO: Hugo knows the way
+	r := refresh.Refresh{}
+	n := node.Node{}
+	addr := address.New("127.0.0.1:1234")
+	n.Init(addr)
+	val := "hello world"
+	hash := kademliaid.NewKademliaID(&val)
 
+	// should not fail if the value is not stored in the nodes datastore
+	r.ParseOptions(&[]string{hash.String()})
+	r.Execute(&n)
 }
 
 func TestParseOption(t *testing.T) {
-	// TODO: Hugo knows the way
+	r := refresh.Refresh{}
+	val := "hello world"
+	hash := kademliaid.NewKademliaID(&val)
 
-}
+	// should parse the hash
+	err := r.ParseOptions(&[]string{hash.String()})
+	assert.Nil(t, err)
 
-func TestPrintUsage(t *testing.T) {
-	// should be equal
-
+	// should return an error when the hash is missing
+	err = r.ParseOptions(&[]string{})
+	assert.NotNil(t, err)
 }

--- a/internal/rpcpool/rpcpool_test.go
+++ b/internal/rpcpool/rpcpool_test.go
@@ -6,26 +6,39 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+// Mock of the HOF supplied to the WithLock function
+type FnMock struct {
+	mock.Mock
+}
+
+func (m *FnMock) Exec() {
+	m.Called()
+	return
+}
 
 func TestNew(t *testing.T) {
 	pool := *rpcpool.New()
 	assert.NotNil(t, pool)
-
 }
 
 func TestAdd(t *testing.T) {
 	pool := *rpcpool.New()
 	id := kademliaid.NewRandomKademliaID()
+
+	// should add a new entry
 	assert.Nil(t, pool.GetEntry(id))
 	pool.Add(id)
 	assert.NotNil(t, pool.GetEntry(id))
-
 }
 
 func TestGetEntry(t *testing.T) {
 	pool := *rpcpool.New()
 	id := kademliaid.NewRandomKademliaID()
+
+	// should return the entry
 	assert.Nil(t, pool.GetEntry(id))
 	pool.Add(id)
 	assert.NotNil(t, pool.GetEntry(id))
@@ -34,8 +47,20 @@ func TestGetEntry(t *testing.T) {
 func TestDelete(t *testing.T) {
 	pool := *rpcpool.New()
 	id := kademliaid.NewRandomKademliaID()
+
+	// should delete the entry
 	pool.Add(id)
 	assert.NotNil(t, pool.GetEntry(id))
 	pool.Delete(id)
 	assert.Nil(t, pool.GetEntry(id))
+}
+
+func TestWithLock(t *testing.T) {
+	pool := *rpcpool.New()
+	funcMock := new(FnMock)
+	funcMock.On("Exec").Return()
+
+	// should call the supplied function after locking the pool
+	pool.WithLock(func() { funcMock.Exec() })
+	funcMock.AssertNumberOfCalls(t, "Exec", 1)
 }

--- a/internal/shortlist/shortlist_test.go
+++ b/internal/shortlist/shortlist_test.go
@@ -47,6 +47,18 @@ func TestNewShortlist(t *testing.T) {
 	}
 }
 
+func TestLess(t *testing.T) {
+	var sl shortlist.Shortlist
+
+	// Should return true if the second element is nil
+	sl = shortlist.Shortlist{Entries: [5]*shortlist.Entry{&shortlist.Entry{}, nil}}
+	assert.Equal(t, true, sl.Less(0, 1))
+
+	// Should return false if the first element is nil and second is not
+	sl = shortlist.Shortlist{Entries: [5]*shortlist.Entry{nil, &shortlist.Entry{}}}
+	assert.Equal(t, false, sl.Less(0, 1))
+}
+
 func TestLen(t *testing.T) {
 	addr := address.New("address")
 	candidates := []contact.Contact{


### PR DESCRIPTION
After this the main coverage we are missing is the LookupData and LookupNode methods in `node.go`. The problem with these methods (and the other ones we are still missing IRC) is that they use the other methods such as LookupDataHandleResponses, and these can't be mocked unless we rewrite using Interfaces so we can use these methods inside another function in the interface that we can mock.

PR on what we have so far at least (around ~70% coverage).