### PR TITLE
Update prod env vars

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -25,9 +25,10 @@ services:
       - ALPHA=3
       - LISTEN_PORT=1776
       - SEND_PORT=1777
-      - REFRESH_TIME=3500
+      - REFRESH_TIME=5
       - BUCKET_REFRESH_TIME=3500
-      - TTL_TIME=3600
+      - TTL_TIME=10
 
 networks:
   kademlia_network:
+


### PR DESCRIPTION
Lowered the TTL and refresh time on prod to make it easier to demonstrate the functionality of the network in prod (which we will use during the sprint review)